### PR TITLE
Use ManifestWork delete policy to keep the managed cluster appsub namespace

### DIFF
--- a/build/e2e-kc.sh
+++ b/build/e2e-kc.sh
@@ -96,3 +96,30 @@ else
     echo "02-placementrule: appsub deployment pod is deleted"
 fi
 echo "PASSED test case 02-placementrule"
+
+### 03-keep-namespace
+echo "STARTING test 03-keep-namespace"
+kubectl config use-context kind-hub
+kubectl create ns test-case-03
+kubectl apply -f test/e2e/cases/03-keep-namespace/
+sleep 30
+
+kubectl config use-context kind-cluster1
+if kubectl get ns test-case-03; then 
+    echo "03-keep-namespace: cluster1 namespace 03-keep-namespace is created"
+else
+    echo "03-keep-namespace FAILED: cluster1 namespace 03-keep-namespace is not present"
+    exit 1
+fi
+
+kubectl config use-context kind-hub
+kubectl delete -f test/e2e/cases/03-keep-namespace/
+sleep 30
+kubectl config use-context kind-cluster1
+if kubectl get ns test-case-03; then 
+    echo "03-keep-namespace: cluster1 namespace 03-keep-namespace is still present"
+else
+    echo "03-keep-namespace FAILED: cluster1 namespace 03-keep-namespace is not present"
+    exit 1
+fi
+echo "PASSED test case 03-keep-namespace"

--- a/pkg/controller/mcmhub/propagate_manifestwork.go
+++ b/pkg/controller/mcmhub/propagate_manifestwork.go
@@ -248,6 +248,20 @@ func (r *ReconcileSubscription) setLocalManifestWork(cluster ManageClusters, hos
 		},
 	}
 
+	localManifestWork.Spec.DeleteOption = &manifestWorkV1.DeleteOption{
+		PropagationPolicy: manifestWorkV1.DeletePropagationPolicyTypeSelectivelyOrphan,
+		SelectivelyOrphan: &manifestWorkV1.SelectivelyOrphan{
+			OrphaningRules: []manifestWorkV1.OrphaningRule{
+				{
+					Group:     "",
+					Namespace: "",
+					Resource:  "namespaces",
+					Name:      appsub.GetNamespace(),
+				},
+			},
+		},
+	}
+
 	for i := 0; i < len(localManifestWork.Spec.Workload.Manifests); i++ {
 		klog.V(1).Infof("workload manifest: %#v", string(localManifestWork.Spec.Workload.Manifests[i].Raw))
 	}

--- a/pkg/placementrule/controller/placementrule/placementrule_controller_test.go
+++ b/pkg/placementrule/controller/placementrule/placementrule_controller_test.go
@@ -517,6 +517,6 @@ func TestClusterChange(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	if len(decision.Status.Decisions) != 2 {
-		t.Errorf("Failed to get all(2) clusters, placementdecision: %v", result)
+		t.Errorf("Failed to get all(2) clusters, placementdecision: %v", decision)
 	}
 }

--- a/test/e2e/cases/03-keep-namespace/channel.yaml
+++ b/test/e2e/cases/03-keep-namespace/channel.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: demo-helmrepo
+  namespace: default
+spec:
+    type: HelmRepo
+    pathname: https://charts.helm.sh/stable/
+    insecureSkipVerify: true

--- a/test/e2e/cases/03-keep-namespace/clusterset.yaml
+++ b/test/e2e/cases/03-keep-namespace/clusterset.yaml
@@ -1,0 +1,4 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ManagedClusterSet
+metadata:
+  name: app-demo

--- a/test/e2e/cases/03-keep-namespace/clustersetbinding.yaml
+++ b/test/e2e/cases/03-keep-namespace/clustersetbinding.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ManagedClusterSetBinding
+metadata:
+  name: app-demo
+  namespace: test-case-03
+spec:
+  clusterSet: app-demo

--- a/test/e2e/cases/03-keep-namespace/placement.yaml
+++ b/test/e2e/cases/03-keep-namespace/placement.yaml
@@ -1,0 +1,14 @@
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: Placement
+metadata:
+  name: demo-placement
+  namespace: test-case-03
+spec:
+  numberOfClusters: 1
+  clusterSets:
+    - app-demo
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            purpose: test

--- a/test/e2e/cases/03-keep-namespace/subscription.yaml
+++ b/test/e2e/cases/03-keep-namespace/subscription.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: demo-subscription
+  namespace: test-case-03
+spec:
+  channel: default/demo-helmrepo
+  name: nginx-ingress
+  placement:
+    placementRef: 
+      name: demo-placement
+      kind: Placement
+  packageOverrides:
+  - packageName: nginx-ingress
+    packageAlias: nginx-ingress-simple
+    packageOverrides:
+    - path: spec
+      value:
+        defaultBackend:
+          replicaCount: 2


### PR DESCRIPTION
for https://github.com/stolostron/backlog/issues/19939

Signed-off-by: Mike Ng <ming@redhat.com>