### PR TITLE
handle channel and secret namespace changes between hub and managed

### DIFF
--- a/pkg/helmrelease/utils/helmrepoutils_test.go
+++ b/pkg/helmrelease/utils/helmrepoutils_test.go
@@ -65,7 +65,7 @@ func TestGetConfig(t *testing.T) {
 	}
 
 	configMapResp, err := GetConfigMap(c, configMapNS, configMapRef)
-	assert.NoError(t, err)
+	assert.Error(t, err)
 
 	assert.Nil(t, configMapResp)
 


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

Channel configmap and secret always gets copied into subscription's namespace on managed cluster. 