### PR TITLE
don't include namespace for cluster scoped resources in subscription …

### DIFF
--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -252,11 +252,15 @@ func (sync *KubeSynchronizer) ProcessSubResources(appsub *appv1alpha1.Subscripti
 		appSubUnitStatus.APIVersion = resource.Resource.GetAPIVersion()
 		appSubUnitStatus.Kind = resource.Resource.GetKind()
 		appSubUnitStatus.Name = resource.Resource.GetName()
-		appSubUnitStatus.Namespace = resource.Resource.GetNamespace()
 
 		pkgGVR, isNamespaced, err := sync.getGVRfromGVK(resource.Gvk.Group, resource.Gvk.Version, resource.Gvk.Kind)
 
+		if isNamespaced {
+			appSubUnitStatus.Namespace = resource.Resource.GetNamespace()
+		}
+
 		if err != nil {
+			appSubUnitStatus.Namespace = resource.Resource.GetNamespace()
 			appSubUnitStatus.Phase = string(appSubStatusV1alpha1.PackageDeployFailed)
 			appSubUnitStatus.Message = err.Error()
 			appSubUnitStatuses = append(appSubUnitStatuses, appSubUnitStatus)


### PR DESCRIPTION
…status report

Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://github.com/stolostron/backlog/issues/21477

The fix has two parts:
1. when generating the subscriptionStatus, the cluster scoped resources should not include namespace
2. In the app subscriptionReport resource list, the cluster scoped resources should not include namespace as well
