### PR TITLE
Adding the Updated column for Subscription

### DIFF
--- a/addon/manifests/chart/templates/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
+++ b/addon/manifests/chart/templates/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
@@ -19,6 +19,9 @@ spec:
   - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date
+  - jsonPath: .status.lastUpdateTime
+    name: Updated
+    type: date
   - JSONPath: .spec.placement.local
     name: Local placement
     type: boolean

--- a/deploy/crds/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
+++ b/deploy/crds/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
@@ -21,8 +21,11 @@ spec:
     - description: subscription status reference
       jsonPath: .status.appstatusReference
       name: AppstatusReference
-      type: string      
+      type: string
     - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.lastUpdateTime
       name: Age
       type: date
     - jsonPath: .spec.placement.local

--- a/deploy/crds/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
+++ b/deploy/crds/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
@@ -26,7 +26,7 @@ spec:
       name: Age
       type: date
     - jsonPath: .status.lastUpdateTime
-      name: Age
+      name: Updated
       type: date
     - jsonPath: .spec.placement.local
       name: Local placement

--- a/pkg/apis/apps/v1/subscription_types.go
+++ b/pkg/apis/apps/v1/subscription_types.go
@@ -285,6 +285,7 @@ type SubscriptionStatus struct {
 // +kubebuilder:printcolumn:name="SubscriptionState",type="string",JSONPath=".status.phase",description="subscription state"
 // +kubebuilder:printcolumn:name="AppstatusReference",type="string",JSONPath=".status.appstatusReference",description="subscription status reference"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Updated",type="date",JSONPath=".status.lastUpdateTime"
 // +kubebuilder:printcolumn:name="Local placement",type="boolean",JSONPath=".spec.placement.local"
 // +kubebuilder:printcolumn:name="Time window",type="string",JSONPath=".spec.timewindow.windowtype"
 // +kubebuilder:resource:shortName=appsub


### PR DESCRIPTION
This PR is adding another column into the `Subscription` CRD that will show the last time when the resource was updated. This little improvement helps people to debug problems a little bit easier.

It would be great if the `Subscription` resource would contain also the time of the last reconciliation that could be then added as yet another column. Unfortunately such information is not available in the `status` yet.