### PR TITLE
Use git-core package instead of git in Docker image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN  microdnf update -y \ 
         && rpm -e --nodeps tzdata \
         && microdnf install tzdata \
-        && microdnf install git \
+        && microdnf install git-core \
         && microdnf install openssh-clients \
         && microdnf clean all
 

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -9,7 +9,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN  microdnf update -y \ 
         && rpm -e --nodeps tzdata \
         && microdnf install tzdata \
-        && microdnf install git \
+        && microdnf install git-core \
         && microdnf install openssh-clients \
         && microdnf clean all
 


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://github.com/stolostron/backlog/issues/22152

apply git-core to avoid unnecessary python pip package dependency, which has cve  - pyup.io-38765 (CVE-2019-20916)

The PR is for fixing image scan failure for the subscription release-2.3 branch