### PR TITLE
Use git-core package instead of git in Docker image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN  microdnf update -y \ 
         && rpm -e --nodeps tzdata \
         && microdnf install tzdata \
-        && microdnf install git \
+        && microdnf install git-core \
         && microdnf install openssh-clients \
         && microdnf clean all
 

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -47,7 +47,7 @@ if [ "$TRAVIS_BUILD" != 1 ]; then
     sed -i -e "s|image: .*:community-latest$|image: $BUILD_IMAGE|" deploy/standalone/operator.yaml
 
     echo -e "\nDownload and install KinD\n"
-    GO111MODULE=on go get sigs.k8s.io/kind
+    GO111MODULE=on go get sigs.k8s.io/kind@v0.11.1
 
 
 else


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://github.com/stolostron/backlog/issues/22152

apply git-core to avoid unnecessary python pip package dependency, which has cve  - pyup.io-38765 (CVE-2019-20916)

The PR is for fixing image scan failure for the subscription release-2.2 branch