### PR TITLE
Add ability to enable Helm chart resources recreate and modification revert.

### DIFF
--- a/addon/manifests/chart/templates/apps.open-cluster-management.io_helmreleases_crd.yaml
+++ b/addon/manifests/chart/templates/apps.open-cluster-management.io_helmreleases_crd.yaml
@@ -404,6 +404,9 @@ spec:
                 description: InsecureSkipVerify is used to skip repo server's TLS
                   certificate verification
                 type: boolean
+              watchNamespaceScopedResources:
+                description: WatchNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+                type: boolean
               secretRef:
                 description: Secret to use to access the helm-repo defined in the
                   CatalogSource.

--- a/addon/manifests/chart/templates/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
+++ b/addon/manifests/chart/templates/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
@@ -92,6 +92,9 @@ spec:
                 - kinds
                 type: object
               type: array
+            watchHelmNamespaceScopedResources:
+              description: WatchHelmNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+              type: boolean
             hooksecretref:
               description: 'ObjectReference contains enough information to let you
                 inspect or modify the referred object. --- New uses of this type are
@@ -567,6 +570,9 @@ spec:
                   - kinds
                   type: object
                 type: array
+              watchHelmNamespaceScopedResources:
+                description: WatchHelmNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+                type: boolean
               hooksecretref:
                 description: 'ObjectReference contains enough information to let you
                   inspect or modify the referred object. --- New uses of this type

--- a/build/e2e-kc.sh
+++ b/build/e2e-kc.sh
@@ -428,3 +428,33 @@ fi
 kubectl config use-context kind-hub
 kubectl delete -f test/e2e/cases/15-git-helm/install
 echo "PASSED test case 15-git-helm"
+
+### 16-helm-recreate
+echo "STARTING test 16-helm-recreate"
+kubectl config use-context kind-hub
+kubectl apply -f test/e2e/cases/16-helm-recreate
+sleep 30
+if kubectl get subscriptions.apps.open-cluster-management.io nginx-helm-sub | grep Propagated; then
+    echo "16-helm-recreate: nginx-helm-sub status is Propagated"
+else
+    echo "16-helm-recreate FAILED: nginx-helm-sub status is not Propagated"
+    exit 1
+fi
+kubectl config use-context kind-cluster1
+if kubectl delete service nginx-ingress-simple-controller; then
+    echo "16-helm-recreate: service nginx-ingress-simple-controller is deleted"
+else
+    echo "16-helm-recreate FAILED: service nginx-ingress-simple-controller is not deleted"
+    exit 1
+fi
+sleep 10
+if kubectl get service nginx-ingress-simple-controller; then
+    echo "16-helm-recreate: service nginx-ingress-simple-controller is recreated"
+else
+    echo "16-helm-recreate FAILED: service nginx-ingress-simple-controller is not recreated"
+    exit 1
+fi
+
+kubectl config use-context kind-hub
+kubectl delete -f test/e2e/cases/16-helm-recreate
+echo "PASSED test case 16-helm-recreate"

--- a/deploy/common/apps.open-cluster-management.io_helmreleases_crd.yaml
+++ b/deploy/common/apps.open-cluster-management.io_helmreleases_crd.yaml
@@ -78,6 +78,9 @@ spec:
                 description: InsecureSkipVerify is used to skip repo server's TLS
                   certificate verification
                 type: boolean
+              watchNamespaceScopedResources:
+                description: WatchNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+                type: boolean
               secretRef:
                 description: Secret to use to access the helm-repo defined in the
                   CatalogSource.

--- a/deploy/common/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
+++ b/deploy/common/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
@@ -250,6 +250,9 @@ spec:
                   - kinds
                   type: object
                 type: array
+              watchHelmNamespaceScopedResources:
+                description: WatchHelmNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+                type: boolean
               placement:
                 description: For hub use only, to specify which clusters to go to
                 properties:

--- a/deploy/crds/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
+++ b/deploy/crds/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
@@ -21,7 +21,7 @@ spec:
     - description: subscription status reference
       jsonPath: .status.appstatusReference
       name: AppstatusReference
-      type: string
+      type: string      
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -257,6 +257,9 @@ spec:
                   - kinds
                   type: object
                 type: array
+              watchHelmNamespaceScopedResources:
+                description: WatchHelmNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+                type: boolean
               placement:
                 description: For hub use only, to specify which clusters to go to
                 properties:

--- a/deploy/hub-common/apps.open-cluster-management.io_helmreleases_crd.yaml
+++ b/deploy/hub-common/apps.open-cluster-management.io_helmreleases_crd.yaml
@@ -78,6 +78,9 @@ spec:
                 description: InsecureSkipVerify is used to skip repo server's TLS
                   certificate verification
                 type: boolean
+              watchNamespaceScopedResources:
+                description: WatchNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+                type: boolean
               secretRef:
                 description: Secret to use to access the helm-repo defined in the
                   CatalogSource.

--- a/deploy/hub-common/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
+++ b/deploy/hub-common/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
@@ -250,6 +250,9 @@ spec:
                   - kinds
                   type: object
                 type: array
+              watchHelmNamespaceScopedResources:
+                description: WatchHelmNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+                type: boolean
               placement:
                 description: For hub use only, to specify which clusters to go to
                 properties:

--- a/deploy/managed-common/apps.open-cluster-management.io_helmreleases_crd.yaml
+++ b/deploy/managed-common/apps.open-cluster-management.io_helmreleases_crd.yaml
@@ -78,6 +78,9 @@ spec:
                 description: InsecureSkipVerify is used to skip repo server's TLS
                   certificate verification
                 type: boolean
+              watchNamespaceScopedResources:
+                description: WatchNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+                type: boolean
               secretRef:
                 description: Secret to use to access the helm-repo defined in the
                   CatalogSource.

--- a/deploy/managed-common/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
+++ b/deploy/managed-common/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
@@ -250,6 +250,9 @@ spec:
                   - kinds
                   type: object
                 type: array
+              watchHelmNamespaceScopedResources:
+                description: WatchHelmNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+                type: boolean
               placement:
                 description: For hub use only, to specify which clusters to go to
                 properties:

--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/apps.open-cluster-management.io_helmreleases_crd_v1.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/apps.open-cluster-management.io_helmreleases_crd_v1.yaml
@@ -81,6 +81,9 @@ spec:
                 description: InsecureSkipVerify is used to skip repo server's TLS
                   certificate verification
                 type: boolean
+              watchNamespaceScopedResources:
+                description: WatchNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+                type: boolean
               secretRef:
                 description: Secret to use to access the helm-repo defined in the
                   CatalogSource.

--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
@@ -257,6 +257,9 @@ spec:
                   - kinds
                   type: object
                 type: array
+              watchHelmNamespaceScopedResources:
+                description: WatchHelmNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+                type: boolean
               placement:
                 description: For hub use only, to specify which clusters to go to
                 properties:

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,4 +64,3 @@ export GITHUB_TOKEN=<github_token>
 make
 make build-images
 ```
-

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20220321153916-2c7772ba3064
 	golang.org/x/net v0.0.0-20220412020605-290c469a71a5
+	gomodules.xyz/jsonpatch/v3 v3.0.1
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	helm.sh/helm/v3 v3.8.0
 	k8s.io/api v0.23.3
@@ -35,7 +36,7 @@ require (
 	k8s.io/klog/v2 v2.40.1
 	open-cluster-management.io/addon-framework v0.3.0
 	open-cluster-management.io/api v0.6.1-0.20220208144021-3297cac74dc5
-	open-cluster-management.io/multicloud-operators-channel v0.7.1-0.20220613142140-d7335819a1e0
+	open-cluster-management.io/multicloud-operators-channel v0.7.1-0.20220413191652-67d1cc8d57fc
 	sigs.k8s.io/controller-runtime v0.11.0
 	sigs.k8s.io/kustomize/api v0.11.1
 	sigs.k8s.io/kustomize/kyaml v0.13.3
@@ -77,7 +78,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
-	github.com/containerd/containerd v1.6.6 // indirect
+	github.com/containerd/containerd v1.6.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v20.10.12+incompatible // indirect
@@ -181,6 +182,7 @@ require (
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
 	golang.org/x/tools v0.1.10 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	gomodules.xyz/orderedmap v0.1.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac // indirect
 	google.golang.org/grpc v1.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,9 +129,8 @@ github.com/Microsoft/hcsshim v0.8.20/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwT
 github.com/Microsoft/hcsshim v0.8.21/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim v0.8.23/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
 github.com/Microsoft/hcsshim v0.9.1/go.mod h1:Y/0uV2jUab5kBI7SQgl62at0AVX7uaruzADAVmxm3eM=
+github.com/Microsoft/hcsshim v0.9.2 h1:wB06W5aYFfUB3IvootYAY2WnOmIdgPGfqSI6tufQNnY=
 github.com/Microsoft/hcsshim v0.9.2/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
-github.com/Microsoft/hcsshim v0.9.3 h1:k371PzBuRrz2b+ebGuI2nVgVhgsVX60jMfSw80NECxo=
-github.com/Microsoft/hcsshim v0.9.3/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -331,9 +330,8 @@ github.com/containerd/containerd v1.5.2/go.mod h1:0DOxVqwDy2iZvrZp2JUx/E+hS0UNTV
 github.com/containerd/containerd v1.5.7/go.mod h1:gyvv6+ugqY25TiXxcZC3L5yOeYgEw0QMhscqVp1AR9c=
 github.com/containerd/containerd v1.5.8/go.mod h1:YdFSv5bTFLpG2HIYmfqDpSYYTDX+mc5qtSuYx1YUb/s=
 github.com/containerd/containerd v1.5.9/go.mod h1:fvQqCfadDGga5HZyn3j4+dx56qj2I9YwBrlSdalvJYQ=
-github.com/containerd/containerd v1.6.1/go.mod h1:1nJz5xCZPusx6jJU8Frfct988y0NpumIq9ODB0kLtoE=
-github.com/containerd/containerd v1.6.6 h1:xJNPhbrmz8xAMDNoVjHy9YHtWwEQNS+CDkcIRh7t8Y0=
-github.com/containerd/containerd v1.6.6/go.mod h1:ZoP1geJldzCVY3Tonoz7b1IXk8rIX0Nltt5QE4OMNk0=
+github.com/containerd/containerd v1.6.2 h1:pcaPUGbYW8kBw6OgIZwIVIeEhdWVrBzsoCfVJ5BjrLU=
+github.com/containerd/containerd v1.6.2/go.mod h1:sidY30/InSE1j2vdD1ihtKoJz+lWdaXMdiAeIupaf+s=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
@@ -352,7 +350,6 @@ github.com/containerd/go-cni v1.0.1/go.mod h1:+vUpYxKvAF72G9i1WoDOiPGRtQpqsNW/ZH
 github.com/containerd/go-cni v1.0.2/go.mod h1:nrNABBHzu0ZwCug9Ije8hL2xBCYh/pjfMb1aZGrrohk=
 github.com/containerd/go-cni v1.1.0/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
 github.com/containerd/go-cni v1.1.3/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
-github.com/containerd/go-cni v1.1.6/go.mod h1:BWtoWl5ghVymxu6MBjg79W9NZrCRyHIdUtk4cauMe34=
 github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3/go.mod h1:IV7qH3hrUgRmyYrtgEeGWJfWbgcHL9CSRruz2Vqcph0=
 github.com/containerd/go-runc v0.0.0-20190911050354-e029b79d8cda/go.mod h1:IV7qH3hrUgRmyYrtgEeGWJfWbgcHL9CSRruz2Vqcph0=
 github.com/containerd/go-runc v0.0.0-20200220073739-7016d3ce2328/go.mod h1:PpyHrqVs8FTi9vpyHwPwiNEGaACDxT/N/pLcvMSRA9g=
@@ -363,7 +360,6 @@ github.com/containerd/imgcrypt v1.0.4-0.20210301171431-0ae5c75f59ba/go.mod h1:6T
 github.com/containerd/imgcrypt v1.1.1-0.20210312161619-7ed62a527887/go.mod h1:5AZJNI6sLHJljKuI9IHnw1pWqo/F0nGDOuR9zgTs7ow=
 github.com/containerd/imgcrypt v1.1.1/go.mod h1:xpLnwiQmEUJPvQoAapeb2SNCxz7Xr6PJrXQb0Dpc4ms=
 github.com/containerd/imgcrypt v1.1.3/go.mod h1:/TPA1GIDXMzbj01yd8pIbQiLdQxed5ue1wb8bP7PQu4=
-github.com/containerd/imgcrypt v1.1.4/go.mod h1:LorQnPtzL/T0IyCeftcsMEO7AqxUDbdO8j/tSUpgxvo=
 github.com/containerd/nri v0.0.0-20201007170849-eb1350a75164/go.mod h1:+2wGSDGFYfE5+So4M5syatU0N0f0LbWpuqyMi4/BE8c=
 github.com/containerd/nri v0.0.0-20210316161719-dbaa18c31c14/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
 github.com/containerd/nri v0.1.0/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
@@ -387,16 +383,13 @@ github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v1.0.1/go.mod h1:AKuhXbN5EzmD4yTNtfSsX3tPcmtrBI6QcRV0NiNt15Y=
-github.com/containernetworking/cni v1.1.1/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
 github.com/containernetworking/plugins v1.0.1/go.mod h1:QHCfGpaTwYTbbH+nZXKVTxNBDZcxSOplJT5ico8/FLE=
-github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19sZPp3ry5uHSkI4LPxV8=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=
 github.com/containers/ocicrypt v1.1.0/go.mod h1:b8AOe0YR67uU8OqfVNcznfFpAzu3rdgUV4GP9qXPfu4=
 github.com/containers/ocicrypt v1.1.1/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
 github.com/containers/ocicrypt v1.1.2/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
-github.com/containers/ocicrypt v1.1.3/go.mod h1:xpdkbVAuaH3WzbEabUd5yDsl9SwJA5pABH85425Es2g=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -514,6 +507,7 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -1040,7 +1034,6 @@ github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3N
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
-github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mikefarah/yq/v3 v3.0.0-20201202084205-8846255d1c37/go.mod h1:dYWq+UWoFCDY1TndvFUQuhBbIYmZpjreC8adEAx93zE=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -1104,7 +1097,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
-github.com/networkplumbing/go-nft v0.2.0/go.mod h1:HnnM+tYvlGAsMU7yoYwXEVLLiDW9gdMmb5HoGcwpuQs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
@@ -1154,7 +1146,6 @@ github.com/opencontainers/image-spec v1.0.0/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.2-0.20211117181255-693428a734f5/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.3-0.20220303224323-02efb9a75ee1 h1:9iFHD5Kt9hkOfeawBNiEeEaV7bmC4/Z5wJp8E9BptMs=
 github.com/opencontainers/image-spec v1.0.3-0.20220303224323-02efb9a75ee1/go.mod h1:K/JAU0m27RFhDRX4PcFdIKntROP6y5Ed6O91aZYDQfs=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -1164,7 +1155,6 @@ github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rm
 github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84SM2ImC1fxBuqJ/H0=
 github.com/opencontainers/runc v1.0.2/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runc v1.1.0/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
-github.com/opencontainers/runc v1.1.2/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2-0.20190207185410-29686dbc5559/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -1176,7 +1166,6 @@ github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqi
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
-github.com/opencontainers/selinux v1.10.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/openshift/api v0.0.0-20211209135129-c58d9f695577 h1:NUe82M8wMYXbd5s+WBAJ2QAZZivs+nhZ3zYgZFwKfqw=
 github.com/openshift/api v0.0.0-20211209135129-c58d9f695577/go.mod h1:DoslCwtqUpr3d/gsbq4ZlkaMEdYqKxuypsDjorcHhME=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
@@ -1226,7 +1215,6 @@ github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQ
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
-github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.12.1 h1:ZiaPsmm9uiBeaSMRznKsCDNtPCS0T3JVDGF+06gjBzk=
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -1937,6 +1925,10 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1N
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.2.0 h1:4pT439QV83L+G9FkcCriY6EkpcK6r6bK+A5FBUMI7qY=
 gomodules.xyz/jsonpatch/v2 v2.2.0/go.mod h1:WXp+iVDkoLQqPudfQ9GBlwB2eZ5DKOnjQZCYdOS8GPY=
+gomodules.xyz/jsonpatch/v3 v3.0.1 h1:Te7hKxV52TKCbNYq3t84tzKav3xhThdvSsSp/W89IyI=
+gomodules.xyz/jsonpatch/v3 v3.0.1/go.mod h1:CBhndykehEwTOlEfnsfJwvkFQbSN8YZFr9M+cIHAJto=
+gomodules.xyz/orderedmap v0.1.0 h1:fM/+TGh/O1KkqGR5xjTKg6bU8OKBkg7p0Y+x/J9m8Os=
+gomodules.xyz/orderedmap v0.1.0/go.mod h1:g9/TPUCm1t2gwD3j3zfV8uylyYhVdCNSi+xCEIu7yTU=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=
@@ -2325,8 +2317,8 @@ open-cluster-management.io/api v0.5.1-0.20220112073018-2d280a97a052/go.mod h1:0I
 open-cluster-management.io/api v0.6.0/go.mod h1:0IUTh8J+p4pv1THh1r9oO0luX9Z1FLDEAmvzW09qC0o=
 open-cluster-management.io/api v0.6.1-0.20220208144021-3297cac74dc5 h1:0Zn4+5qfXTHCjoa7pg8+fI/Gebr4bQDHWR+d1XPa47c=
 open-cluster-management.io/api v0.6.1-0.20220208144021-3297cac74dc5/go.mod h1:0IUTh8J+p4pv1THh1r9oO0luX9Z1FLDEAmvzW09qC0o=
-open-cluster-management.io/multicloud-operators-channel v0.7.1-0.20220613142140-d7335819a1e0 h1:MhKJ/sitzq3INCUJHDwLhzVsTy1A/R9vk2aWNb91YRE=
-open-cluster-management.io/multicloud-operators-channel v0.7.1-0.20220613142140-d7335819a1e0/go.mod h1:EZXt7Is8UjJrIetiTKyZSCXCWYvyxHp7cCOTprT20BM=
+open-cluster-management.io/multicloud-operators-channel v0.7.1-0.20220413191652-67d1cc8d57fc h1:PVLeG9gab6YCC+ilbDaLJFGs2mgC/yEFQEarMLU6YmU=
+open-cluster-management.io/multicloud-operators-channel v0.7.1-0.20220413191652-67d1cc8d57fc/go.mod h1:G7CbabcOmZxZ7UWSc6Ek4NEZzjcH0xYJSopFj2dyMYo=
 oras.land/oras-go v0.4.0/go.mod h1:VJcU+VE4rkclUbum5C0O7deEZbBYnsnpbGSACwTjOcg=
 oras.land/oras-go v1.1.0 h1:tfWM1RT7PzUwWphqHU6ptPU3ZhwVnSw/9nEGf519rYg=
 oras.land/oras-go v1.1.0/go.mod h1:1A7vR/0KknT2UkJVWh+xMi95I/AhK8ZrxrnUSmXN0bQ=

--- a/hack/test/apps.open-cluster-management.io_helmrelease_crd.yaml
+++ b/hack/test/apps.open-cluster-management.io_helmrelease_crd.yaml
@@ -81,6 +81,9 @@ spec:
                 description: InsecureSkipVerify is used to skip repo server's TLS
                   certificate verification
                 type: boolean
+              watchNamespaceScopedResources:
+                description: WatchNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+                type: boolean
               secretRef:
                 description: Secret to use to access the helm-repo defined in the
                   CatalogSource.

--- a/pkg/apis/apps/helmrelease/v1/helmrelease_types.go
+++ b/pkg/apis/apps/helmrelease/v1/helmrelease_types.go
@@ -111,26 +111,28 @@ func (s AltSource) String() string {
 
 func (repo HelmReleaseRepo) Clone() HelmReleaseRepo {
 	return HelmReleaseRepo{
-		ChartName:          repo.ChartName,
-		Version:            repo.Version,
-		Digest:             repo.Digest,
-		AltSource:          repo.AltSource,
-		SecretRef:          repo.SecretRef,
-		ConfigMapRef:       repo.ConfigMapRef,
-		InsecureSkipVerify: repo.InsecureSkipVerify,
-		Source:             repo.Source,
+		ChartName:                     repo.ChartName,
+		Version:                       repo.Version,
+		Digest:                        repo.Digest,
+		AltSource:                     repo.AltSource,
+		SecretRef:                     repo.SecretRef,
+		ConfigMapRef:                  repo.ConfigMapRef,
+		InsecureSkipVerify:            repo.InsecureSkipVerify,
+		Source:                        repo.Source,
+		WatchNamespaceScopedResources: repo.WatchNamespaceScopedResources,
 	}
 }
 
 func (repo HelmReleaseRepo) AltSourceToSource() HelmReleaseRepo {
 	return HelmReleaseRepo{
-		ChartName:          repo.ChartName,
-		Version:            repo.Version,
-		Digest:             repo.Digest,
-		AltSource:          repo.AltSource,
-		SecretRef:          repo.AltSource.SecretRef,
-		ConfigMapRef:       repo.AltSource.ConfigMapRef,
-		InsecureSkipVerify: repo.AltSource.InsecureSkipVerify,
+		ChartName:                     repo.ChartName,
+		Version:                       repo.Version,
+		Digest:                        repo.Digest,
+		WatchNamespaceScopedResources: repo.WatchNamespaceScopedResources,
+		AltSource:                     repo.AltSource,
+		SecretRef:                     repo.AltSource.SecretRef,
+		ConfigMapRef:                  repo.AltSource.ConfigMapRef,
+		InsecureSkipVerify:            repo.AltSource.InsecureSkipVerify,
 		Source: &Source{
 			SourceType: repo.AltSource.SourceType,
 			GitHub:     repo.AltSource.GitHub,
@@ -162,6 +164,8 @@ type HelmReleaseRepo struct {
 	ConfigMapRef *corev1.ObjectReference `json:"configMapRef,omitempty"`
 	// InsecureSkipVerify is used to skip repo server's TLS certificate verification
 	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
+	// WatchNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+	WatchNamespaceScopedResources bool `json:"watchNamespaceScopedResources,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/apps/v1/subscription_types.go
+++ b/pkg/apis/apps/v1/subscription_types.go
@@ -196,6 +196,8 @@ type SubscriptionSpec struct {
 	HookSecretRef *corev1.ObjectReference `json:"hooksecretref,omitempty"`
 	Allow         []*AllowDenyItem        `json:"allow,omitempty"`
 	Deny          []*AllowDenyItem        `json:"deny,omitempty"`
+	// WatchHelmNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+	WatchHelmNamespaceScopedResources bool `json:"watchHelmNamespaceScopedResources,omitempty"`
 }
 
 // SubscriptionPhase defines the phasing of a Subscription

--- a/pkg/controller/mcmhub/propagate_manifestwork.go
+++ b/pkg/controller/mcmhub/propagate_manifestwork.go
@@ -316,6 +316,7 @@ func (r *ReconcileSubscription) prepareManifestWorkAppsub(appsub *appSubV1.Subsc
 	subep.Spec.HookSecretRef = appsub.Spec.HookSecretRef
 	subep.Spec.Allow = appsub.Spec.Allow
 	subep.Spec.Deny = appsub.Spec.Deny
+	subep.Spec.WatchHelmNamespaceScopedResources = appsub.Spec.WatchHelmNamespaceScopedResources
 	subep.Spec.SecondaryChannel = appsub.Spec.SecondaryChannel
 
 	subepanno := r.updateSubAnnotations(appsub, hosting)

--- a/pkg/helmrelease/client/client.go
+++ b/pkg/helmrelease/client/client.go
@@ -140,7 +140,7 @@ func (c *ownerRefInjectingClient) Build(reader io.Reader, validate bool) (kube.R
 			return err
 		}
 		u := &unstructured.Unstructured{Object: objMap}
-		useOwnerRef, err := k8sutil.SupportsOwnerReference(c.restMapper, c.owner, u)
+		useOwnerRef, err := k8sutil.SupportsOwnerReference(c.restMapper, c.owner, u, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/helmrelease/controller/helmrelease/helmrelease_controller.go
+++ b/pkg/helmrelease/controller/helmrelease/helmrelease_controller.go
@@ -27,14 +27,20 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ghodss/yaml"
+	libpredicate "github.com/operator-framework/operator-lib/predicate"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/kube"
+	rpb "helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
@@ -49,6 +55,7 @@ import (
 	appv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/helmrelease/v1"
 	appsubv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 	appSubStatusV1alpha1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1alpha1"
+	"open-cluster-management.io/multicloud-operators-subscription/pkg/helmrelease/internal/util/k8sutil"
 	helmoperator "open-cluster-management.io/multicloud-operators-subscription/pkg/helmrelease/release"
 	kubesynchronizer "open-cluster-management.io/multicloud-operators-subscription/pkg/synchronizer/kubernetes"
 )
@@ -71,17 +78,6 @@ func Add(mgr manager.Manager) error {
 		return err
 	}
 
-	return add(mgr, newReconciler(mgr, synchronizer))
-}
-
-// newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, synchronizer *kubesynchronizer.KubeSynchronizer) reconcile.Reconciler {
-
-	return &ReconcileHelmRelease{mgr, synchronizer}
-}
-
-// add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	chartsDir := os.Getenv(appv1.ChartsDir)
 	if chartsDir == "" {
 		chartsDir = "/tmp/hr-charts"
@@ -91,6 +87,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			return err
 		}
 	}
+
+	r := &ReconcileHelmRelease{mgr, synchronizer, nil}
 
 	klog.Info("The MaxConcurrentReconciles is set to: ", defaultMaxConcurrent)
 
@@ -106,16 +104,22 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	watchDependentResources(mgr, r, c)
+
 	return nil
 }
 
 // blank assignment to verify that ReconcileHelmRelease implements reconcile.Reconciler
 var _ reconcile.Reconciler = &ReconcileHelmRelease{}
 
+// ReleaseHookFunc defines a function signature for release hooks.
+type ReleaseHookFunc func(*rpb.Release) error
+
 // ReconcileHelmRelease reconciles a HelmRelease object
 type ReconcileHelmRelease struct {
 	manager.Manager
 	synchronizer *kubesynchronizer.KubeSynchronizer
+	releaseHook  ReleaseHookFunc
 }
 
 // Reconcile reads that state of the cluster for a HelmRelease object and makes changes based on the state read
@@ -308,6 +312,30 @@ func (r *ReconcileHelmRelease) Reconcile(ctx context.Context, request reconcile.
 	// no longer being attempted.
 	instance.Status.RemoveCondition(appv1.ConditionReleaseFailed)
 
+	if instance.Repo.WatchNamespaceScopedResources {
+		klog.Info("Reapplying Release ", helmreleaseNsn(instance))
+
+		expectedRelease, err := manager.ReconcileRelease(ctx)
+		if err != nil {
+			klog.Error(err, "Failed to reconcile release")
+			instance.Status.SetCondition(appv1.HelmAppCondition{
+				Type:    appv1.ConditionReleaseFailed,
+				Status:  appv1.StatusTrue,
+				Reason:  appv1.ReasonReconcileError,
+				Message: err.Error(),
+			})
+			_ = r.updateResourceStatus(instance)
+			return reconcile.Result{}, err
+		}
+
+		if r.releaseHook != nil {
+			if err := r.releaseHook(expectedRelease); err != nil {
+				klog.Error(err, "Failed to run release hook")
+				return reconcile.Result{}, err
+			}
+		}
+	}
+
 	return r.ensureStatusReasonPopulated(instance, manager)
 }
 
@@ -459,6 +487,13 @@ func (r *ReconcileHelmRelease) install(instance *appv1.HelmRelease, manager helm
 		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
 	}
 
+	if r.releaseHook != nil {
+		if err := r.releaseHook(installedRelease); err != nil {
+			klog.Error(err, "Failed to run release hook")
+			return reconcile.Result{}, err
+		}
+	}
+
 	klog.Info("Installed HelmRelease ", helmreleaseNsn(instance))
 
 	message := ""
@@ -547,6 +582,13 @@ func (r *ReconcileHelmRelease) upgrade(instance *appv1.HelmRelease, manager helm
 		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
 	}
 	instance.Status.RemoveCondition(appv1.ConditionReleaseFailed)
+
+	if r.releaseHook != nil {
+		if err := r.releaseHook(upgradedRelease); err != nil {
+			klog.Error(err, "Failed to run release hook")
+			return reconcile.Result{}, err
+		}
+	}
 
 	klog.Info("Upgraded HelmRelease ", "force=", force, " for ", helmreleaseNsn(instance))
 	message := ""
@@ -975,4 +1017,87 @@ func joinErrors(errs []error) string {
 		es = append(es, e.Error())
 	}
 	return strings.Join(es, "; ")
+}
+
+// coped and modified from https://github.com/operator-framework/operator-sdk/blob/v1.22.0/internal/helm/controller/controller.go
+func watchDependentResources(mgr manager.Manager, r *ReconcileHelmRelease, c controller.Controller) {
+	owner := &unstructured.Unstructured{}
+	owner.SetGroupVersionKind(
+		schema.GroupVersionKind{
+			Group:   "apps.open-cluster-management.io",
+			Version: "v1",
+			Kind:    "HelmRelease"},
+	)
+
+	var m sync.RWMutex
+	watches := map[schema.GroupVersionKind]struct{}{}
+	releaseHook := func(release *rpb.Release) error {
+		resources := releaseutil.SplitManifests(release.Manifest)
+		for _, resource := range resources {
+			var u unstructured.Unstructured
+			if err := yaml.Unmarshal([]byte(resource), &u); err != nil {
+				return err
+			}
+
+			gvk := u.GroupVersionKind()
+			if gvk.Empty() {
+				continue
+			}
+
+			var setWatchOnResource = func(dependent runtime.Object) error {
+				unstructuredObj := dependent.(*unstructured.Unstructured)
+				gvkDependent := unstructuredObj.GroupVersionKind()
+				if gvkDependent.Empty() {
+					return nil
+				}
+
+				m.RLock()
+				_, ok := watches[gvkDependent]
+				m.RUnlock()
+				if ok {
+					return nil
+				}
+
+				restMapper := mgr.GetRESTMapper()
+				useOwnerRef, err := k8sutil.SupportsOwnerReference(restMapper, owner, dependent, "")
+				if err != nil {
+					return err
+				}
+
+				if useOwnerRef { // Setup watch using owner references.
+					err = c.Watch(&source.Kind{Type: unstructuredObj}, &handler.EnqueueRequestForOwner{OwnerType: owner},
+						libpredicate.DependentPredicate{})
+					if err != nil {
+						return err
+					}
+				}
+				m.Lock()
+				watches[gvkDependent] = struct{}{}
+				m.Unlock()
+				klog.Info("Watching dependent resource", "ownerApiVersion", owner.GroupVersionKind().GroupVersion(),
+					"ownerKind", owner.GroupVersionKind().Kind, "apiVersion", gvkDependent.GroupVersion(), "kind", gvkDependent.Kind)
+				return nil
+			}
+
+			// List is not actually a resource and therefore cannot have a
+			// watch on it. The watch will be on the kinds listed in the list
+			// and will therefore need to be handled individually.
+			listGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "List"}
+			if gvk == listGVK {
+				errListItem := u.EachListItem(func(obj runtime.Object) error {
+					return setWatchOnResource(obj)
+				})
+				if errListItem != nil {
+					return errListItem
+				}
+			} else {
+				err := setWatchOnResource(&u)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	r.releaseHook = releaseHook
 }

--- a/pkg/helmrelease/controller/helmrelease/helmrelease_controller_test.go
+++ b/pkg/helmrelease/controller/helmrelease/helmrelease_controller_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -65,7 +66,14 @@ func TestReconcile(t *testing.T) {
 	rec := &ReconcileHelmRelease{
 		mgr,
 		nil,
+		nil,
 	}
+
+	// Create a new controller
+	ctrl, err := controller.New("helmrelease-controller", mgr, controller.Options{Reconciler: rec})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	watchDependentResources(mgr, rec, ctrl)
 
 	t.Log("Setup test reconcile")
 	g.Expect(Add(mgr)).NotTo(gomega.HaveOccurred())

--- a/pkg/helmrelease/internal/util/k8sutil/k8sutil.go
+++ b/pkg/helmrelease/internal/util/k8sutil/k8sutil.go
@@ -22,12 +22,14 @@ import (
 )
 
 // SupportsOwnerReference checks whether a given dependent supports owner references, based on the owner.
+// The namespace of the dependent resource can either be passed in explicitly, otherwise it will be
+// extracted from the dependent runtime.Object.
 // This function performs following checks:
 //  -- True: Owner is cluster-scoped.
 //  -- True: Both Owner and dependent are Namespaced with in same namespace.
 //  -- False: Owner is Namespaced and dependent is Cluster-scoped.
 //  -- False: Both Owner and dependent are Namespaced with different namespaces.
-func SupportsOwnerReference(restMapper meta.RESTMapper, owner, dependent runtime.Object) (bool, error) {
+func SupportsOwnerReference(restMapper meta.RESTMapper, owner, dependent runtime.Object, depNamespace string) (bool, error) {
 	ownerGVK := owner.GetObjectKind().GroupVersionKind()
 	ownerMapping, err := restMapper.RESTMapping(ownerGVK.GroupKind(), ownerGVK.Version)
 	if err != nil {
@@ -50,7 +52,9 @@ func SupportsOwnerReference(restMapper meta.RESTMapper, owner, dependent runtime
 	ownerClusterScoped := ownerMapping.Scope.Name() == meta.RESTScopeNameRoot
 	ownerNamespace := mOwner.GetNamespace()
 	depClusterScoped := depMapping.Scope.Name() == meta.RESTScopeNameRoot
-	depNamespace := mDep.GetNamespace()
+	if depNamespace == "" {
+		depNamespace = mDep.GetNamespace()
+	}
 
 	if ownerClusterScoped {
 		return true, nil

--- a/pkg/helmrelease/internal/util/k8sutil/k8sutil_test.go
+++ b/pkg/helmrelease/internal/util/k8sutil/k8sutil_test.go
@@ -28,11 +28,12 @@ import (
 
 func TestSupportsOwnerReference(t *testing.T) {
 	type testcase struct {
-		name       string
-		restMapper meta.RESTMapper
-		owner      runtime.Object
-		dependent  runtime.Object
-		result     bool
+		name         string
+		restMapper   meta.RESTMapper
+		owner        runtime.Object
+		dependent    runtime.Object
+		result       bool
+		depNamespace string
 	}
 
 	var defaultVersion []schema.GroupVersion
@@ -203,11 +204,61 @@ func TestSupportsOwnerReference(t *testing.T) {
 			},
 			result: false,
 		},
+		{
+			name:         "Returns true if depNamespace provided and matches.",
+			restMapper:   restMapper,
+			depNamespace: "ns",
+			owner: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "MyNamespaceKind",
+					"apiVersion": "apps/v1alpha1",
+					"metadata": map[string]interface{}{
+						"name":      "example-nginx-controller",
+						"namespace": "ns",
+					},
+				},
+			},
+			dependent: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "MyNamespaceKind",
+					"apiVersion": "apps/v1alpha1",
+					"metadata": map[string]interface{}{
+						"name": "example-nginx-role",
+					},
+				},
+			},
+			result: true,
+		},
+		{
+			name:         "Returns false if depNamespace provided and doesn't match.",
+			restMapper:   restMapper,
+			depNamespace: "ns1",
+			owner: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "MyNamespaceKind",
+					"apiVersion": "apps/v1alpha1",
+					"metadata": map[string]interface{}{
+						"name":      "example-nginx-controller",
+						"namespace": "ns",
+					},
+				},
+			},
+			dependent: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "MyNamespaceKind",
+					"apiVersion": "apps/v1alpha1",
+					"metadata": map[string]interface{}{
+						"name": "example-nginx-role",
+					},
+				},
+			},
+			result: false,
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			useOwner, err := SupportsOwnerReference(c.restMapper, c.owner, c.dependent)
+			useOwner, err := SupportsOwnerReference(c.restMapper, c.owner, c.dependent, c.depNamespace)
 			if err != nil {
 				assert.Error(t, err)
 			}

--- a/pkg/placementrule/utils/label_test.go
+++ b/pkg/placementrule/utils/label_test.go
@@ -1,0 +1,31 @@
+// Copyright 2021 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package utils
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestValidateK8sLabel(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	APIServer := "_-.api.xili-aws-cluster-pool-tg2g4.dev06.red-chesterfield.com_-."
+	expectedServerLabel := "api.xili-aws-cluster-pool-tg2g4.dev06.red-chesterfield.com"
+
+	ServerLabel := ValidateK8sLabel(APIServer)
+
+	g.Expect(ServerLabel).Should(gomega.Equal(expectedServerLabel))
+}

--- a/pkg/synchronizer/kubernetes/sync_appsubstatus.go
+++ b/pkg/synchronizer/kubernetes/sync_appsubstatus.go
@@ -28,6 +28,11 @@ import (
 	"open-cluster-management.io/multicloud-operators-subscription/pkg/utils"
 )
 
+const (
+	localSuffix  = "-local"
+	localCluster = "local-cluster"
+)
+
 /*
 
 use {apiversion, kind, namespace, name} as the key to build new appsubPackaggeStatus map and existing appsubPackaggeStatus map
@@ -74,10 +79,10 @@ func (sync *KubeSynchronizer) SyncAppsubClusterStatus(appsub *appv1.Subscription
 	appsubName := appsubClusterStatus.AppSub.Name
 	pkgstatusNs := appsubClusterStatus.AppSub.Namespace
 	isLocalCluster := (sync.hub && !sync.standalone) ||
-		(appsubClusterStatus.Cluster == "" && strings.HasSuffix(appsubName, "-local"))
+		(appsubClusterStatus.Cluster == localCluster && strings.HasSuffix(appsubName, localSuffix))
 
 	if isLocalCluster || sync.standalone && skipOrphanDel {
-		if strings.HasSuffix(appsubName, "-local") {
+		if strings.HasSuffix(appsubName, localSuffix) {
 			appsubName = appsubName[:len(appsubName)-6]
 		}
 	}
@@ -413,8 +418,8 @@ func updateAppsubReportResult(rClient client.Client, appsubNs, appsubName,
 		// Check if a hosting-subscription exists
 		appsub := &v1.Subscription{}
 
-		if isLocalCluster && !strings.HasSuffix(appsubName, "-local") {
-			appsubName += "-local"
+		if isLocalCluster && !strings.HasSuffix(appsubName, localSuffix) {
+			appsubName += localSuffix
 		}
 
 		if err := rClient.Get(context.TODO(),
@@ -429,11 +434,11 @@ func updateAppsubReportResult(rClient client.Client, appsubNs, appsubName,
 			return nil
 		}
 
-		if strings.HasSuffix(appsubName, "-local") {
+		if strings.HasSuffix(appsubName, localSuffix) {
 			appsubName = appsubName[:len(appsubName)-6]
 		}
 
-		clusterAppsubReportNs = "local-cluster"
+		clusterAppsubReportNs = localCluster
 
 		klog.V(1).Infof("Standalone appsub for helm, continue")
 	}
@@ -512,7 +517,7 @@ func deleteAppsubReportResult(rClient client.Client, appsubNs, appsubName, clust
 			return nil
 		}
 
-		clusterAppsubReportNs = "local-cluster"
+		clusterAppsubReportNs = localCluster
 
 		klog.V(1).Infof("Standalone appsub for helm, continue")
 	}

--- a/pkg/synchronizer/kubernetes/synchronizer_test.go
+++ b/pkg/synchronizer/kubernetes/synchronizer_test.go
@@ -33,8 +33,8 @@ import (
 
 var (
 	host = types.NamespacedName{
-		Name:      "cluster1",
-		Namespace: "cluster1",
+		Name:      "cluster2",
+		Namespace: "cluster2",
 	}
 	hostworkload4 = types.NamespacedName{
 		Name:      "subscription-4",
@@ -104,6 +104,19 @@ var (
 			Namespace: "default",
 			Annotations: map[string]string{
 				appv1alpha1.AnnotationHosting: "not owned",
+			},
+		},
+	}
+	workload4Configmap = corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "configmap2",
+			Namespace: "default",
+			Annotations: map[string]string{
+				appv1alpha1.AnnotationResourceDoNotDeleteOption: "true",
 			},
 		},
 	}
@@ -204,9 +217,6 @@ var _ = Describe("test Delete Single Subscribed Resource", func() {
 	})
 
 	It("should not be owned by the subscription", func() {
-		sync, err := CreateSynchronizer(k8sManager.GetConfig(), k8sManager.GetConfig(), k8sManager.GetScheme(), &host, 2, nil, false, false)
-		Expect(err).NotTo(HaveOccurred())
-
 		workload1 := workload3Configmap.DeepCopy()
 		Expect(k8sClient.Create(context.TODO(), workload1)).NotTo(HaveOccurred())
 
@@ -221,6 +231,23 @@ var _ = Describe("test Delete Single Subscribed Resource", func() {
 
 		err = sync.DeleteSingleSubscribedResource(hostSub, pkgStatus)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should not delete if the resource has do-not-delete annotation", func() {
+		workload1 := workload4Configmap.DeepCopy()
+		Expect(k8sClient.Create(context.TODO(), workload1)).NotTo(HaveOccurred())
+
+		defer k8sClient.Delete(context.TODO(), workload1)
+
+		pkgStatus := appSubStatusV1alpha1.SubscriptionUnitStatus{
+			Name:       "configmap2",
+			Namespace:  "default",
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		}
+
+		err = sync.DeleteSingleSubscribedResource(hostSub, pkgStatus)
+		Expect(err).To(BeNil())
 	})
 })
 

--- a/pkg/utils/helmrepo.go
+++ b/pkg/utils/helmrepo.go
@@ -255,14 +255,15 @@ func CreateOrUpdateHelmChart(
 					}},
 				},
 				Repo: releasev1.HelmReleaseRepo{
-					Source:             source,
-					ConfigMapRef:       channel.Spec.ConfigMapRef,
-					InsecureSkipVerify: channel.Spec.InsecureSkipVerify,
-					SecretRef:          channel.Spec.SecretRef,
-					ChartName:          packageName,
-					Version:            version,
-					Digest:             digest,
-					AltSource:          altSource,
+					Source:                        source,
+					ConfigMapRef:                  channel.Spec.ConfigMapRef,
+					InsecureSkipVerify:            channel.Spec.InsecureSkipVerify,
+					SecretRef:                     channel.Spec.SecretRef,
+					ChartName:                     packageName,
+					Version:                       version,
+					Digest:                        digest,
+					AltSource:                     altSource,
+					WatchNamespaceScopedResources: sub.Spec.WatchHelmNamespaceScopedResources,
 				},
 			}
 		} else {
@@ -290,14 +291,15 @@ func CreateOrUpdateHelmChart(
 		helmRelease.Spec = nil
 
 		helmRelease.Repo = releasev1.HelmReleaseRepo{
-			Source:             source,
-			ConfigMapRef:       channel.Spec.ConfigMapRef,
-			InsecureSkipVerify: channel.Spec.InsecureSkipVerify,
-			SecretRef:          channel.Spec.SecretRef,
-			ChartName:          packageName,
-			Version:            version,
-			Digest:             digest,
-			AltSource:          altSource,
+			Source:                        source,
+			ConfigMapRef:                  channel.Spec.ConfigMapRef,
+			InsecureSkipVerify:            channel.Spec.InsecureSkipVerify,
+			SecretRef:                     channel.Spec.SecretRef,
+			ChartName:                     packageName,
+			Version:                       version,
+			Digest:                        digest,
+			AltSource:                     altSource,
+			WatchNamespaceScopedResources: sub.Spec.WatchHelmNamespaceScopedResources,
 		}
 	}
 

--- a/test/e2e/cases/16-helm-recreate/01-channel.yaml
+++ b/test/e2e/cases/16-helm-recreate/01-channel.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  annotations:
+    apps.open-cluster-management.io/reconcile-rate: high
+  name: dev-helmrepo
+  namespace: default
+spec:
+  type: HelmRepo
+  pathname: https://charts.helm.sh/stable/
+  insecureSkipVerify: true

--- a/test/e2e/cases/16-helm-recreate/02-placementrule.yaml
+++ b/test/e2e/cases/16-helm-recreate/02-placementrule.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: nginx-pr
+  namespace: default
+spec:
+  clusterReplicas: 10

--- a/test/e2e/cases/16-helm-recreate/02-subscription.yaml
+++ b/test/e2e/cases/16-helm-recreate/02-subscription.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: nginx-helm-sub
+  namespace: default
+spec:
+  watchHelmNamespaceScopedResources: true
+  channel: default/dev-helmrepo
+  name: nginx-ingress
+  placement:
+    placementRef:
+      kind: PlacementRule
+      name: nginx-pr
+  packageFilter:
+    version: "1.36.3"
+  packageOverrides:
+  - packageName: nginx-ingress
+    packageAlias: nginx-ingress-simple
+    packageOverrides:
+    - path: spec
+      value:
+        defaultBackend:
+          replicaCount: 2


### PR DESCRIPTION
Add new Subscription Spec.WatchHelmNamespaceScopedResources to optionally enable watch Helm chart namespace resources. If enabled, deleted resources will get recreated and modified resources will be reverted.

Also fixed an issue where HelmRelease is deleted from a managed cluster manually, it doesn't get auto recreated.

For https://github.com/stolostron/backlog/issues/23521

Signed-off-by: Mike Ng <ming@redhat.com>