### PR TITLE
Fix appv1 change

### DIFF
--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -815,7 +815,7 @@ func sortKubeResource(crdsAndNamespaceFiles, rbacFiles, otherFiles []string, pat
 
 		if err != nil {
 			klog.Error(err, "Failed to read YAML file "+path)
-			return crdsAndNamespaceFiles, rbacFiles, otherFiles, nil
+			return crdsAndNamespaceFiles, rbacFiles, otherFiles, err
 		}
 
 		resources := ParseKubeResoures(file)
@@ -827,7 +827,7 @@ func sortKubeResource(crdsAndNamespaceFiles, rbacFiles, otherFiles []string, pat
 			if err != nil {
 				klog.Warning("Failed to unmarshal YAML file")
 				// Just ignore the YAML
-				return crdsAndNamespaceFiles, rbacFiles, otherFiles, err
+				return crdsAndNamespaceFiles, rbacFiles, otherFiles, nil
 			}
 
 			if t.APIVersion != "" && t.Kind != "" {

--- a/pkg/utils/helmrepo_test.go
+++ b/pkg/utils/helmrepo_test.go
@@ -33,7 +33,7 @@ import (
 	chnv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 
 	releasev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/helmrelease/v1"
-	appv1alpha1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
+	appv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 )
 
 var (
@@ -53,12 +53,12 @@ var (
 		},
 	}
 
-	helmsub = &appv1alpha1.Subscription{
+	helmsub = &appv1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      helmkey.Name,
 			Namespace: helmkey.Namespace,
 		},
-		Spec: appv1alpha1.SubscriptionSpec{
+		Spec: appv1.SubscriptionSpec{
 			Channel: helmkey.String(),
 		},
 	}
@@ -70,14 +70,14 @@ func TestGetPackageAlias(t *testing.T) {
 	pkgAlias := GetPackageAlias(githubsub, "")
 	g.Expect(pkgAlias).To(gomega.Equal(""))
 
-	pkgOverrides1 := &appv1alpha1.Overrides{}
+	pkgOverrides1 := &appv1.Overrides{}
 	pkgOverrides1.PackageName = "pkgName1"
 
-	pkgOverrides2 := &appv1alpha1.Overrides{}
+	pkgOverrides2 := &appv1.Overrides{}
 	pkgOverrides2.PackageName = "pkgName2"
 	pkgOverrides2.PackageAlias = "pkgName2Alias"
 
-	packageOverrides := make([]*appv1alpha1.Overrides, 0)
+	packageOverrides := make([]*appv1.Overrides, 0)
 	packageOverrides = append(packageOverrides, pkgOverrides1, pkgOverrides2)
 
 	githubsub.Spec.PackageOverrides = packageOverrides
@@ -229,7 +229,7 @@ func TestCheckVersion(t *testing.T) {
 	chartDirs := make(map[string]string)
 	chartDirs["../../test/github/helmcharts/chart1/"] = "../../test/github/helmcharts/chart1/"
 
-	packageFilter := &appv1alpha1.PackageFilter{}
+	packageFilter := &appv1.PackageFilter{}
 	packageFilter.Version = "1.1.1"
 
 	githubsub.Spec.PackageFilter = packageFilter
@@ -247,10 +247,10 @@ func TestCheckVersion(t *testing.T) {
 	g.Expect(ret).To(gomega.BeTrue())
 
 	subanno := make(map[string]string)
-	subanno[appv1alpha1.AnnotationGitPath] = "test/github/helmcharts"
+	subanno[appv1.AnnotationGitPath] = "test/github/helmcharts"
 	githubsub.SetAnnotations(subanno)
 
-	packageFilter = &appv1alpha1.PackageFilter{}
+	packageFilter = &appv1.PackageFilter{}
 	packageFilter.Version = "2.0.0"
 
 	githubsub.Spec.PackageFilter = packageFilter
@@ -258,13 +258,13 @@ func TestCheckVersion(t *testing.T) {
 	ret = checkVersion(githubsub, chartVersion)
 	g.Expect(ret).To(gomega.BeFalse())
 
-	packageFilter = &appv1alpha1.PackageFilter{}
+	packageFilter = &appv1.PackageFilter{}
 	githubsub.Spec.PackageFilter = packageFilter
 
 	ret = checkVersion(githubsub, chartVersion)
 	g.Expect(ret).To(gomega.BeTrue())
 
-	packageFilter = &appv1alpha1.PackageFilter{}
+	packageFilter = &appv1.PackageFilter{}
 	packageFilter.Version = "v2.0.0"
 
 	githubsub.Spec.PackageFilter = packageFilter
@@ -272,7 +272,7 @@ func TestCheckVersion(t *testing.T) {
 	ret = checkVersion(githubsub, chartVersion)
 	g.Expect(ret).To(gomega.BeFalse())
 
-	packageFilter = &appv1alpha1.PackageFilter{}
+	packageFilter = &appv1.PackageFilter{}
 	githubsub.Spec.PackageFilter = packageFilter
 
 	ret = checkVersion(githubsub, chartVersion)
@@ -314,7 +314,7 @@ spec:
 persistence:
   enabled: false`
 
-	sub2 := &appv1alpha1.Subscription{}
+	sub2 := &appv1.Subscription{}
 	err = yaml.Unmarshal([]byte(substr2), &sub2)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -359,7 +359,7 @@ func TestCreateHelmCRManifest(t *testing.T) {
 	chartDirs["../../test/github/helmcharts/chart1Upgrade/"] = "../../test/github/helmcharts/chart1Upgrade/"
 	chartDirs["../../test/github/helmcharts/chart2/"] = "../../test/github/helmcharts/chart2/"
 
-	packageFilter := &appv1alpha1.PackageFilter{}
+	packageFilter := &appv1.PackageFilter{}
 	packageFilter.Version = "1.1.1"
 
 	githubsub.Spec.PackageFilter = packageFilter


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

Changed wrong revert from https://github.com/stolostron/multicloud-operators-subscription/pull/781#discussion_r916256235
line 818 should be err and line 830 should be nil as was originally 
Also changed missing removal of alpha1 from appv1 in helmrepo_test.go