### PR TITLE
kube 1.24 service account token secret changes

### DIFF
--- a/pkg/controller/spoketoken/spoke_token_controller.go
+++ b/pkg/controller/spoketoken/spoke_token_controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/url"
+	"strings"
 	"time"
 
 	ocinfrav1 "github.com/openshift/api/config/v1"
@@ -88,6 +89,12 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Watch for changes to klusterlet-addon-appmgr service account token secret in open-cluster-management-agent-addon namespace.
+	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{}, utils.AddonSATokenSecretPredicateFunctions)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -129,14 +136,17 @@ func (r *ReconcileAgentToken) Reconcile(ctx context.Context, request reconcile.R
 				klog.Error("Failed to delete the secret from the hub.")
 				return reconcile.Result{RequeueAfter: requeuAfter * time.Minute}, err
 			}
-		} else {
-			klog.Errorf("Failed to get serviceaccount %v, error: %v", request.NamespacedName, err)
-			return reconcile.Result{RequeueAfter: requeuAfter * time.Minute}, err
+
+			return reconcile.Result{}, nil
 		}
+
+		klog.Errorf("Failed to get serviceaccount %v, error: %v", request.NamespacedName, err)
+
+		return reconcile.Result{RequeueAfter: requeuAfter * time.Minute}, err
 	}
 
 	// Get the service account token from the service account's secret list
-	saSecret := r.getServiceAccountTokenSecret(*appmgrsa)
+	saSecret := r.getServiceAccountTokenSecret()
 
 	if saSecret == nil {
 		klog.Error("Failed to find the service account token.")
@@ -244,27 +254,27 @@ func (r *ReconcileAgentToken) prepareAgentTokenSecret(token string) *corev1.Secr
 	return mcSecret
 }
 
-func (r *ReconcileAgentToken) getServiceAccountTokenSecret(sa corev1.ServiceAccount) *corev1.Secret {
-	// Get the service account token from the service account's secret list
-	saSecret := &corev1.Secret{}
+func (r *ReconcileAgentToken) getServiceAccountTokenSecret() *corev1.Secret {
+	// Get all secrets
+	// list thing for rolling update check
+	secretList := &corev1.SecretList{}
+	listopts := &client.ListOptions{Namespace: "open-cluster-management-agent-addon"}
+	err := r.Client.List(context.TODO(), secretList, listopts)
 
-	for _, secret := range sa.Secrets {
-		secretName := types.NamespacedName{
-			Name:      secret.Name,
-			Namespace: sa.Namespace,
-		}
+	if err != nil {
+		klog.Error(err.Error())
+		return nil
+	}
 
-		if err := r.Client.Get(context.TODO(), secretName, saSecret); err != nil {
-			continue
-		}
-
-		// Get the service account token
-		if saSecret.Type == corev1.SecretTypeServiceAccountToken {
-			break
+	for _, secret := range secretList.Items {
+		// Get the application-manager service account token
+		if secret.Type == corev1.SecretTypeServiceAccountToken && strings.HasPrefix(secret.Name, "application-manager-token-") {
+			klog.Info("found the application-manager service account token secret " + secret.Name)
+			return &secret
 		}
 	}
 
-	return saSecret
+	return nil
 }
 
 // getKubeAPIServerAddress - Get the API server address from OpenShift kubernetes cluster. This does not work with other kubernetes.

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -396,7 +396,8 @@ var ServiceAccountPredicateFunctions = predicate.Funcs{
 	},
 }
 
-// AddonSATokenSecretPredicateFunctions watches for changes in klusterlet-addon-appmgr service account token secret in open-cluster-management-agent-addon namespace
+// AddonSATokenSecretPredicateFunctions watches for changes in klusterlet-addon-appmgr
+// service account token secret in open-cluster-management-agent-addon namespace
 var AddonSATokenSecretPredicateFunctions = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		newSecret := e.ObjectNew.(*corev1.Secret)

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -396,6 +396,37 @@ var ServiceAccountPredicateFunctions = predicate.Funcs{
 	},
 }
 
+// AddonSATokenSecretPredicateFunctions watches for changes in klusterlet-addon-appmgr service account token secret in open-cluster-management-agent-addon namespace
+var AddonSATokenSecretPredicateFunctions = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		newSecret := e.ObjectNew.(*corev1.Secret)
+
+		if strings.EqualFold(newSecret.Namespace, addonServiceAccountNamespace) && strings.HasPrefix(newSecret.Name, addonServiceAccountName+"-token-") {
+			return true
+		}
+
+		return false
+	},
+	CreateFunc: func(e event.CreateEvent) bool {
+		secret := e.Object.(*corev1.Secret)
+
+		if strings.EqualFold(secret.Namespace, addonServiceAccountNamespace) && strings.HasPrefix(secret.Name, addonServiceAccountName+"-token-") {
+			return true
+		}
+
+		return false
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		secret := e.Object.(*corev1.Secret)
+
+		if strings.EqualFold(secret.Namespace, addonServiceAccountNamespace) && strings.HasPrefix(secret.Name, addonServiceAccountName+"-token-") {
+			return true
+		}
+
+		return false
+	},
+}
+
 // GetHostSubscriptionFromObject extract the namespacedname of subscription hosting the object resource
 func GetHostSubscriptionFromObject(obj metav1.Object) *types.NamespacedName {
 	if obj == nil {


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

Kube 1.24 (OCP 4.11) changed the way service account token secret is mounted on the service account. The code is updated to handle this and also backward compatible.

https://github.com/stolostron/backlog/issues/24073