### PR TITLE
release-2.5: Do not run the pre delete hook addon job if it's on the hub cluster

### DIFF
--- a/addon/addon_test.go
+++ b/addon/addon_test.go
@@ -94,7 +94,7 @@ func TestManifest(t *testing.T) {
 			addon:             newAddon(AppMgrAddonName, "local-cluster", "test", ""),
 			expectedNamespace: "test",
 			expectedImage:     "quay.io/open-cluster-management/multicluster_operators_subscription:latest",
-			expectedCount:     6,
+			expectedCount:     5,
 		},
 	}
 	AppMgrImage = "quay.io/open-cluster-management/multicluster_operators_subscription:latest"

--- a/addon/manifests/chart/templates/pre_delete_hook.yaml
+++ b/addon/manifests/chart/templates/pre_delete_hook.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.onHubCluster false }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -28,3 +29,4 @@ spec:
       imagePullSecrets:
       - name: "{{ .Values.global.imagePullSecret }}"
       {{- end }}
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

for https://github.com/stolostron/backlog/issues/24158