### PR TITLE
check if appsubstatus resouce lit empty to avoid panic error

### DIFF
--- a/pkg/synchronizer/kubernetes/sync_appsubstatus.go
+++ b/pkg/synchronizer/kubernetes/sync_appsubstatus.go
@@ -645,6 +645,12 @@ func getClusterAppsubReport(rClient client.Client, clusterAppsubReportNs string,
 
 func shouldSkip(appsubClusterStatus SubscriptionClusterStatus, foundPkgStatus bool,
 	pkgstatus v1alpha1.SubscriptionStatus) bool {
+	if len(pkgstatus.Statuses.SubscriptionStatus) == 0 {
+		klog.Infof("appsubstatus resouse list is empty, appsubstatus: %v/%v", pkgstatus.Namespace, pkgstatus.Name)
+
+		return false
+	}
+
 	if len(appsubClusterStatus.SubscriptionPackageStatus) == 1 &&
 		strings.EqualFold(appsubClusterStatus.SubscriptionPackageStatus[0].Kind, "HelmRelease") &&
 		strings.EqualFold(appsubClusterStatus.SubscriptionPackageStatus[0].APIVersion, "apps.open-cluster-management.io/v1") &&

--- a/pkg/synchronizer/kubernetes/sync_appsubstatus_test.go
+++ b/pkg/synchronizer/kubernetes/sync_appsubstatus_test.go
@@ -550,5 +550,15 @@ var _ = Describe("test create/update/delete appsub status for standalone and man
 		err = s.SyncAppsubClusterStatus(appsubToBeDeleted, rmClusterStatus, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 
+		// shouldSkip should return false when there is appsubstatus with empty status
+		emptyAppsubStatus := appSubStatusV1alpha1.SubscriptionStatus{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "appsubstatus-1",
+				Namespace: "default",
+			},
+			Statuses: appSubStatusV1alpha1.SubscriptionClusterStatusMap{},
+		}
+
+		Expect(shouldSkip(appsubClusterStatus, true, emptyAppsubStatus)).To(BeFalse())
 	})
 })


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://issues.redhat.com/browse/ACM-2519

merge the fix to release-2.6 branch for next 2.6 Z release