### PR TITLE
ACM-4470 Unable to make SSH connection to a bitbucket repo on a non-standard ssh port

### DIFF
--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -412,8 +412,8 @@ func getKnownHostFromURL(sshURL string, filepath string) error {
 	cmd := exec.Command("ssh-keyscan", sshhostname) // #nosec G204 the variable is generated within this function.
 
 	if sshhostport != "" {
-		cmd = exec.Command("ssh-keyscan", sshhostname, "-p", sshhostport) // #nosec G204 the variable is generated within this function.
-		klog.Infof("Running command ssh-keyscan %s -p %s", sshhostname, sshhostport)
+		cmd = exec.Command("ssh-keyscan", "-p", sshhostport, sshhostname) // #nosec G204 the variable is generated within this function.
+		klog.Infof("Running command ssh-keyscan -p %s %s", sshhostport, sshhostname)
 	}
 
 	stdout, err := cmd.Output()


### PR DESCRIPTION
This PR updates the order of the port flag for the `ssh-keyscan` command. Before this PR `ssh-keyscan` was defaulting to port 22 even if another port was specified.

Addresses:
 - https://issues.redhat.com/browse/ACM-4470