### PR TITLE
ACM-3072 Remove PodSecurity warnings from MCH Operator logs

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -507,6 +507,8 @@ spec:
                     memory: 64Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  seccompProfile:
+                    type: RuntimeDefault
                   capabilities:
                     drop:
                     - ALL
@@ -608,6 +610,8 @@ spec:
                   readOnly: false
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                    type: RuntimeDefault
               serviceAccountName: multicluster-applications
               volumes:
               - name: multicluster-integrations-syncresource 
@@ -626,6 +630,8 @@ spec:
             spec:
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                    type: RuntimeDefault
               affinity:
                 podAntiAffinity:
                   preferredDuringSchedulingIgnoredDuringExecution:
@@ -895,6 +901,8 @@ spec:
                 app: multicluster-operators-subscription-report
             spec:
               securityContext:
+                seccompProfile:
+                  type: RuntimeDefault
                 runAsNonRoot: true
               affinity:
                 podAntiAffinity:


### PR DESCRIPTION
Signed-off-by: Erin Murphy <erinmurp@redhat.com>

issue: https://issues.redhat.com/browse/ACM-3072

Description of issue: Installer team is cleaning up our logs, and require the spec seccompProfile to be set to 'RuntimeDefault' 