### PR TITLE
Declare seccompProfile to avoid PodSecurity warnings (#337)

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -507,6 +507,8 @@ spec:
                     memory: 64Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  seccompProfile:
+                    type: RuntimeDefault
                   capabilities:
                     drop:
                     - ALL
@@ -608,6 +610,8 @@ spec:
                   readOnly: false
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: multicluster-applications
               volumes:
               - name: multicluster-integrations-syncresource 
@@ -626,6 +630,8 @@ spec:
             spec:
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               affinity:
                 podAntiAffinity:
                   preferredDuringSchedulingIgnoredDuringExecution:
@@ -896,6 +902,8 @@ spec:
             spec:
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               affinity:
                 podAntiAffinity:
                   preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>
(cherry picked from commit f965b22ed5131c54472319674e51c236e9a4139f)

Cherry-picking sync from https://github.com/stolostron/multicloud-operators-subscription/pull/962 to release-2.8