### PR TITLE
ACM-5451 - Ensure Subscription CRDs are installed

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -264,6 +264,23 @@ func RunManager() {
 		utils.DetectPlacementDecision(sig, mgr.GetAPIReader(), mgr.GetClient())
 	}
 
+	// Detect if the subscription API is ready
+	isHubCluster := false
+	if Options.ClusterName == "" {
+		isHubCluster = true
+	}
+
+	if !utils.IsReadySubscription(mgr.GetAPIReader(), isHubCluster) {
+		for {
+			if !utils.IsReadySubscription(mgr.GetAPIReader(), isHubCluster) {
+				time.Sleep(10 * time.Second)
+			} else { // restart controller when CRDs are found.
+				klog.Info("Subscription API is ready.")
+				os.Exit(1)
+			}
+		}
+	}
+
 	klog.Info("Starting the Cmd.")
 
 	// Start addon manager

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -1228,6 +1228,48 @@ func IsReadyPlacementDecision(clReader client.Reader) bool {
 	return true
 }
 
+// IsReadySubscription check if Subscription API is ready or not.
+func IsReadySubscription(clReader client.Reader, hub bool) bool {
+	subList := appv1.SubscriptionList{}
+
+	listopts := &client.ListOptions{}
+
+	err := clReader.List(context.TODO(), &subList, listopts)
+	if err != nil {
+		klog.Error("Subscription API NOT ready: ", err)
+
+		return false
+	}
+
+	subStatusList := appsubReportV1alpha1.SubscriptionStatusList{}
+
+	err = clReader.List(context.TODO(), &subStatusList, listopts)
+	if err != nil {
+		klog.Error("SubscriptionStatus API NOT ready: ", err)
+
+		return false
+	}
+
+	if hub {
+		subReportList := appsubReportV1alpha1.SubscriptionReportList{}
+
+		err = clReader.List(context.TODO(), &subReportList, listopts)
+		if err != nil {
+			klog.Error("SubscriptionReport API NOT ready: ", err)
+
+			return false
+		}
+
+		klog.Info("Subscription, SubscriptionStatus and SubscriptionReport APIs are ready")
+
+		return true
+	}
+
+	klog.Info("Subscription, and SubscriptionStatus APIs are ready")
+
+	return true
+}
+
 func CreateClusterManagementAddon(clt client.Client) {
 	cma := &addonV1alpha1.ClusterManagementAddOn{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/utils/subscription_test.go
+++ b/pkg/utils/subscription_test.go
@@ -18,8 +18,11 @@ import (
 	"context"
 	"encoding/json"
 	e "errors"
+	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -35,7 +38,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -1703,6 +1709,51 @@ func TestIsReadyPlacementDecision(t *testing.T) {
 	ret := IsReadyPlacementDecision(mgr.GetAPIReader())
 	g.Expect(ret).To(BeFalse())
 }
+
+func TestIsReadySubscription(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "deploy", "crds"),
+			filepath.Join("..", "..", "hack", "test"),
+		},
+	}
+
+	appv1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	appv1alpha1.AddToScheme(scheme.Scheme)
+
+	var (
+		err    error
+		cfgSub *rest.Config
+	)
+
+	if cfgSub, err = tEnv.Start(); err != nil {
+		log.Fatal(fmt.Errorf("got error while start up the envtest, err: %w", err))
+	}
+
+	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
+	// channel when it is finished.
+	mgr, err := manager.New(cfgSub, manager.Options{MetricsBindAddress: "0"})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
+	mgrStopped := StartTestManager(ctx, mgr, g)
+
+	defer func() {
+		cancel()
+		mgrStopped.Wait()
+	}()
+
+	// Subscription API should BE ready on the hub
+	ret := IsReadySubscription(mgr.GetAPIReader(), true)
+	g.Expect(ret).To(BeTrue())
+
+	// Subscription API should BE ready on the managed cluster.
+	ret = IsReadySubscription(mgr.GetAPIReader(), false)
+	g.Expect(ret).To(BeTrue())
+}
+
 func TestFetchChannelReferences(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
Sync https://github.com/open-cluster-management-io/multicloud-operators-subscription/pull/338 to release-2.7

Addresses:
 - https://issues.redhat.com/browse/ACM-5451