### PR TITLE
[release-2.7] Use `release-2.7` for the generator

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,11 @@
 FROM registry.ci.openshift.org/stolostron/builder:go1.19-linux AS plugin-builder
-ENV POLICY_GENERATOR_TAG=v1.10.0
+ENV POLICY_GENERATOR_TAG=release-2.7
 
 WORKDIR /policy-generator
 RUN curl -L -o "policy-generator-plugin.tar.gz" \
-        "https://github.com/stolostron/policy-generator-plugin/archive/refs/tags/${POLICY_GENERATOR_TAG}.tar.gz"
+        "https://github.com/stolostron/policy-generator-plugin/archive/refs/heads/${POLICY_GENERATOR_TAG}.tar.gz"
 RUN tar -xzvf "policy-generator-plugin.tar.gz"
-RUN cd "/policy-generator/policy-generator-plugin-${POLICY_GENERATOR_TAG#*v}" && \
+RUN cd "/policy-generator/policy-generator-plugin-${POLICY_GENERATOR_TAG}" && \
         make build-binary && \
         mv "PolicyGenerator" "/policy-generator/"
 

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/stolostron/builder:go1.19-linux AS builder
-ENV POLICY_GENERATOR_TAG=v1.10.0
+ENV POLICY_GENERATOR_TAG=release-2.7
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-subscription
 COPY . .
@@ -7,9 +7,9 @@ RUN make -f Makefile.prow build
 
 WORKDIR /policy-generator
 RUN curl -L -o "policy-generator-plugin.tar.gz" \
-        "https://github.com/stolostron/policy-generator-plugin/archive/refs/tags/${POLICY_GENERATOR_TAG}.tar.gz"
+        "https://github.com/stolostron/policy-generator-plugin/archive/refs/heads/${POLICY_GENERATOR_TAG}.tar.gz"
 RUN tar -xzvf "policy-generator-plugin.tar.gz"
-RUN cd "/policy-generator/policy-generator-plugin-${POLICY_GENERATOR_TAG#*v}" && \
+RUN cd "/policy-generator/policy-generator-plugin-${POLICY_GENERATOR_TAG}" && \
         make build-binary && \
         mv "PolicyGenerator" "/policy-generator/"
 


### PR DESCRIPTION
* [x] I have taken backward compatibility into consideration.
