### PR TITLE
avoid delete appsub addon CRDs when the regional hub is detached (#34…

### DIFF
--- a/addon/manifests/chart/templates/apps.open-cluster-management.io_helmreleases_crd.yaml
+++ b/addon/manifests/chart/templates/apps.open-cluster-management.io_helmreleases_crd.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
+    {{ if .Values.onMulticlusterHub }}"addon.open-cluster-management.io/deletion-orphan": ""{{ end }}
   name: helmreleases.apps.open-cluster-management.io
 spec:
   group: apps.open-cluster-management.io
@@ -326,6 +327,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
     helm.sh/resource-policy: keep
+    {{ if .Values.onMulticlusterHub }}"addon.open-cluster-management.io/deletion-orphan": ""{{ end }}
   creationTimestamp: null
   name: helmreleases.apps.open-cluster-management.io
 spec:

--- a/addon/manifests/chart/templates/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
+++ b/addon/manifests/chart/templates/apps.open-cluster-management.io_subscriptions_crd_v1.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
+    {{ if .Values.onMulticlusterHub }}"addon.open-cluster-management.io/deletion-orphan": ""{{ end }}
   name: subscriptions.apps.open-cluster-management.io
 spec:
   additionalPrinterColumns:
@@ -483,6 +484,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
+    {{ if .Values.onMulticlusterHub }}"addon.open-cluster-management.io/deletion-orphan": ""{{ end }}
   name: subscriptions.apps.open-cluster-management.io
 spec:
   group: apps.open-cluster-management.io

--- a/addon/manifests/chart/templates/apps.open-cluster-management.io_subscriptionstatuses_crd_v1alpha1.yaml
+++ b/addon/manifests/chart/templates/apps.open-cluster-management.io_subscriptionstatuses_crd_v1alpha1.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
+    {{ if .Values.onMulticlusterHub }}"addon.open-cluster-management.io/deletion-orphan": ""{{ end }}
   name: subscriptionstatuses.apps.open-cluster-management.io
 spec:
   group: apps.open-cluster-management.io
@@ -70,6 +71,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
+    {{ if .Values.onMulticlusterHub }}"addon.open-cluster-management.io/deletion-orphan": ""{{ end }}
   name: subscriptionstatuses.apps.open-cluster-management.io
 spec:
   group: apps.open-cluster-management.io

--- a/addon/manifests/chart/values.yaml
+++ b/addon/manifests/chart/values.yaml
@@ -7,6 +7,7 @@ hubKubeConfigSecret: null
 clusterName: null
 
 onHubCluster: false
+OnMulticlusterHub: false
 
 affinity: {}
 


### PR DESCRIPTION
…4) (#975)


(cherry picked from commit a187d23f7ee4a13372b48112b2d03fa2c8eed1e6)

* [x] I have taken backward compatibility into consideration.

backport the fix to release-2.7

https://issues.redhat.com/browse/ACM-6206