### PR TITLE
stop synchronizing resources list if any kustomization folder fails

### DIFF
--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -357,6 +357,11 @@ func (ghsi *SubscriberItem) doSubscription() error {
 	if err != nil {
 		klog.Error(err, " Unable to subscribe kustomize resources")
 
+		// if any kustmoization fails, stop synchronizing resources list. This is important to handle the case:
+		// If applying one kustomize folder fails after some other kustomize folder success, ghsi.successful is set to faluse for stopping synchronizer.
+		// Or only successfully kustomized resources are deployed,
+		// that will trigger synchronizer to delete those resources that haven't been kustomized but deployed previously
+
 		ghsi.successful = false
 
 		errMsg += err.Error()
@@ -385,7 +390,7 @@ func (ghsi *SubscriberItem) doSubscription() error {
 	// If it failed to add applicable resources to the list, do not apply the empty list.
 	// It will cause already deployed resourced to be removed.
 	// Update the host subscription status accordingly and quit.
-	if len(ghsi.resources) == 0 && !ghsi.successful {
+	if len(ghsi.resources) == 0 || !ghsi.successful {
 		if (ghsi.synchronizer.GetRemoteClient() != nil) && !standaloneSubscription {
 			klog.Error("failed to prepare resources to apply and there is no resource to apply. quit")
 		}


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.
