### PR TITLE
lower MaxConcurrentReconciles to 1 for helmRelease controller for les…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/cli v24.0.6+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
-	github.com/docker/docker v24.0.6+incompatible // indirect
+	github.com/docker/docker v24.0.7+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/docker/cli v24.0.6+incompatible h1:fF+XCQCgJjjQNIMjzaSmiKJSCcfcXb3TWT
 github.com/docker/cli v24.0.6+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v24.0.6+incompatible h1:hceabKCtUgDqPu+qm0NgsaXf28Ljf4/pWFL7xjWWDgE=
-github.com/docker/docker v24.0.6+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.7+incompatible h1:Wo6l37AuwP3JaMnZa226lzVXGA3F9Ig1seQen0cKYlM=
+github.com/docker/docker v24.0.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=

--- a/pkg/helmrelease/controller/helmrelease/helmrelease_controller.go
+++ b/pkg/helmrelease/controller/helmrelease/helmrelease_controller.go
@@ -62,7 +62,7 @@ import (
 const (
 	finalizer = "uninstall-helm-release"
 
-	defaultMaxConcurrent = 10
+	defaultMaxConcurrent = 1
 )
 
 // Add creates a new HelmRelease Controller and adds it to the Manager. The Manager will set fields on the Controller


### PR DESCRIPTION
…s memory consumption

* [X] I have taken backward compatibility into consideration.

Two issues are fixed:
- lower MaxConcurrentReconciles to 1 for helmRelease controller. 
With the previous 10 concurrent setting, we identified there is OOM killed issue in the footprint assessment test env where the managed cluster is SNO cluster with limited memory. Setting it to 1 stabilized the running of the application-manager pod

https://issues.redhat.com/browse/ACM-8936

-  take the chance to upgrade the missing pkg github.com/docker/docker, which is reported by the git repo Dependabot
