### PR TITLE
Deprecation, `gosec`, and spelling fixes (#389)

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -200,7 +200,7 @@ func RunManager() {
 		}
 
 		if !Options.Debug {
-			// Setup Webhook listner
+			// Setup Webhook listener
 			if err := webhook.AddToManager(mgr, hubconfig, Options.TLSKeyFilePathName, Options.TLSCrtFilePathName, Options.DisableTLS, true); err != nil {
 				klog.Error("Failed to initialize WebHook listener with error:", err)
 				os.Exit(1)
@@ -360,7 +360,7 @@ func setupStandalone(mgr manager.Manager, hubconfig *rest.Config, id *types.Name
 	}
 
 	if standalone && !Options.Debug {
-		// Setup Webhook listner
+		// Setup Webhook listener
 		if err := webhook.AddToManager(mgr, hubconfig, Options.TLSKeyFilePathName, Options.TLSCrtFilePathName, Options.DisableTLS, false); err != nil {
 			klog.Error("Failed to initialize WebHook listener with error:", err)
 
@@ -379,13 +379,12 @@ func serveHealthProbes(healthProbeBindAddress string, configCheck healthz.Checke
 		"configz-ping": configCheck,
 	}}))
 
-	/* #nosec G402 */
 	server := http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 		Addr:              healthProbeBindAddress,
 		TLSConfig: &tls.Config{
-			MinVersion: appsubv1.TLSMinVersionInt,
+			MinVersion: appsubv1.TLSMinVersionInt, // #nosec G402 -- TLS 1.2 is required for FIPS
 		},
 	}
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -17,7 +17,7 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -86,7 +86,7 @@ func (r *Runner) Run(runID string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusOK {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/pkg/addonmanager/bindata/bindata.go
+++ b/pkg/addonmanager/bindata/bindata.go
@@ -19,7 +19,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -469,7 +468,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -16,7 +16,7 @@ package mcmhub
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -227,7 +227,7 @@ func (r *ReconcileSubscription) subscribeResources(
 	rscFiles []string, objRefMap map[v1.ObjectReference]*v1.ObjectReference) error {
 	// sync kube resource manifests
 	for _, rscFile := range rscFiles {
-		file, err := ioutil.ReadFile(rscFile) // #nosec G304 rscFile is not user input
+		file, err := os.ReadFile(rscFile) // #nosec G304 rscFile is not user input
 
 		if err != nil {
 			klog.Error(err, "Failed to read YAML file "+rscFile)

--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -17,7 +17,6 @@ package mcmhub
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -699,7 +698,7 @@ func parseAsAnsibleJobs(rscFiles []string, parser func([]byte) [][]byte, logger 
 	jobs := []ansiblejob.AnsibleJob{}
 	// sync kube resource manifests
 	for _, rscFile := range rscFiles {
-		file, err := ioutil.ReadFile(rscFile) // #nosec G304 rscFile is not user input
+		file, err := os.ReadFile(rscFile) // #nosec G304 rscFile is not user input
 
 		if err != nil {
 			return []ansiblejob.AnsibleJob{}, err

--- a/pkg/controller/subscription/lease_controller_test.go
+++ b/pkg/controller/subscription/lease_controller_test.go
@@ -16,7 +16,6 @@ package subscription
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -73,7 +72,7 @@ func TestLeaseReconcile(t *testing.T) {
 	addontNs, _ := utils.GetComponentNamespace()
 	pod.SetNamespace(addontNs)
 
-	tmpFile, err := ioutil.TempFile("", "temptest")
+	tmpFile, err := os.CreateTemp("", "temptest")
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	_, err = tmpFile.WriteString("fake kubeconfig data")

--- a/pkg/helmrelease/utils/helmrepoutils_test.go
+++ b/pkg/helmrelease/utils/helmrepoutils_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -164,7 +163,7 @@ func TestDownloadChartGitHub(t *testing.T) {
 			ChartName: "subscription-release-test-1",
 		},
 	}
-	dir, err := ioutil.TempDir("/tmp", "charts")
+	dir, err := os.MkdirTemp("/tmp", "charts")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -194,7 +193,7 @@ func TestDownloadChartGit(t *testing.T) {
 			ChartName: "subscription-release-test-1",
 		},
 	}
-	dir, err := ioutil.TempDir("/tmp", "charts")
+	dir, err := os.MkdirTemp("/tmp", "charts")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -224,7 +223,7 @@ func TestDownloadChartHelmRepo(t *testing.T) {
 			Digest:    "long-fake-digest-that-is-very-long",
 		},
 	}
-	dir, err := ioutil.TempDir("/tmp", "charts")
+	dir, err := os.MkdirTemp("/tmp", "charts")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -257,7 +256,7 @@ func TestDownloadChartHelmRepoContainsInvalidURL(t *testing.T) {
 			ChartName: "subscription-release-test-1",
 		},
 	}
-	dir, err := ioutil.TempDir("/tmp", "charts")
+	dir, err := os.MkdirTemp("/tmp", "charts")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -286,7 +285,7 @@ func TestDownloadChartHelmRepoContainsInvalidURL2(t *testing.T) {
 			ChartName: "subscription-release-test-1",
 		},
 	}
-	dir, err := ioutil.TempDir("/tmp", "charts")
+	dir, err := os.MkdirTemp("/tmp", "charts")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -314,7 +313,7 @@ func TestDownloadChartHelmRepoAllInvalidURLs(t *testing.T) {
 			ChartName: "subscription-release-test-1",
 		},
 	}
-	dir, err := ioutil.TempDir("/tmp", "charts")
+	dir, err := os.MkdirTemp("/tmp", "charts")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -341,7 +340,7 @@ func TestDownloadChartFromGitHub(t *testing.T) {
 			ChartName: "subscription-release-test-1",
 		},
 	}
-	dir, err := ioutil.TempDir("/tmp", "charts")
+	dir, err := os.MkdirTemp("/tmp", "charts")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -371,7 +370,7 @@ func TestDownloadChartFromGit(t *testing.T) {
 			ChartName: "subscription-release-test-1",
 		},
 	}
-	dir, err := ioutil.TempDir("/tmp", "charts")
+	dir, err := os.MkdirTemp("/tmp", "charts")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -401,7 +400,7 @@ func TestDownloadChartFromHelmRepoHTTP(t *testing.T) {
 			Digest:    "short",
 		},
 	}
-	dir, err := ioutil.TempDir("/tmp", "charts")
+	dir, err := os.MkdirTemp("/tmp", "charts")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -434,7 +433,7 @@ func TestDownloadChartFromHelmRepoHTTPConfigMap(t *testing.T) {
 			Digest:    "short",
 		},
 	}
-	dir, err := ioutil.TempDir("/tmp", "charts")
+	dir, err := os.MkdirTemp("/tmp", "charts")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -470,7 +469,7 @@ func TestDownloadChartFromHelmRepoHTTPNoDigest(t *testing.T) {
 			ChartName: "subscription-release-test-1",
 		},
 	}
-	dir, err := ioutil.TempDir("/tmp", "charts")
+	dir, err := os.MkdirTemp("/tmp", "charts")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -502,7 +501,7 @@ func TestDownloadChartFromHelmRepoLocal(t *testing.T) {
 			Digest:    "digest",
 		},
 	}
-	dir, err := ioutil.TempDir("/tmp", "charts")
+	dir, err := os.MkdirTemp("/tmp", "charts")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -533,7 +532,7 @@ func TestDownloadChartFromHelmRepoLocalNoDigest(t *testing.T) {
 			ChartName: "subscription-release-test-1",
 		},
 	}
-	dir, err := ioutil.TempDir("/tmp", "charts")
+	dir, err := os.MkdirTemp("/tmp", "charts")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -551,7 +550,7 @@ func TestDownloadChartFromHelmRepoLocalNoDigest(t *testing.T) {
 func TestDownloadGitRepo(t *testing.T) {
 	httpURLs := []string{"https://" + testutils.GetTestGitRepoURLFromEnvVar() + ".git"}
 	sshURLs := []string{"ssh://" + testutils.GetTestGitRepoURLFromEnvVar() + ".git"}
-	dir, err := ioutil.TempDir("/tmp", "charts")
+	dir, err := os.MkdirTemp("/tmp", "charts")
 	assert.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -653,7 +652,7 @@ tYny6pJJNYEhf7HPmb2O3zBuuqsCC0O2SHrgFYH350zA4To9Ez5nifkZ0CBx0pn9jWn02V
 }
 
 func TestGetKnownHostFromURL(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "temptest")
+	tmpfile, err := os.CreateTemp("", "temptest")
 	if err != nil {
 		t.Error("error creating temp file")
 	}

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -519,7 +519,7 @@ func checkSubscriptionAnnotation(resource kubeResource) error {
 func (ghsi *SubscriberItem) subscribeResources(rscFiles []string) error {
 	// sync kube resource manifests
 	for _, rscFile := range rscFiles {
-		file, err := ioutil.ReadFile(rscFile) // #nosec G304 rscFile is not user input
+		file, err := os.ReadFile(rscFile) // #nosec G304 rscFile is not user input
 
 		if err != nil {
 			klog.Error(err, "Failed to read YAML file "+rscFile)

--- a/pkg/subscriber/helmrepo/helm_subscriber_item.go
+++ b/pkg/subscriber/helmrepo/helm_subscriber_item.go
@@ -19,7 +19,7 @@ import (
 	"crypto/sha1" // #nosec G505 Used only to generate random value to be used to generate hash string
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -448,10 +448,9 @@ func getHelmRepoClient(chnCfg *corev1.ConfigMap, insecureSkipVerify bool) (*http
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		/* #nosec G402 */
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: insecureSkipVerify, // #nosec G402 InsecureSkipVerify optionally
-			MinVersion:         appv1.TLSMinVersionInt,
+			InsecureSkipVerify: insecureSkipVerify,     // #nosec G402 InsecureSkipVerify optionally
+			MinVersion:         appv1.TLSMinVersionInt, // #nosec G402 -- TLS 1.2 is required for FIPS
 		},
 	}
 
@@ -525,7 +524,7 @@ func getHelmRepoIndex(client rest.HTTPClient, sub *appv1.Subscription,
 
 	klog.V(5).Info("Get succeeded: ", cleanRepoURL)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		klog.Error(err, "Unable to read body: ", cleanRepoURL)
 

--- a/pkg/utils/aws/objectstore.go
+++ b/pkg/utils/aws/objectstore.go
@@ -17,7 +17,7 @@ package aws
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -258,7 +258,7 @@ func (h *Handler) Get(bucket, name string) (DeployableObject, error) {
 
 	generateName := resp.Metadata[DployableMateGenerateNameKey]
 	version := resp.Metadata[DeployableMetaVersionKey]
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		klog.Error("Failed to parse Get request. error: ", err)

--- a/pkg/utils/gitrepo.go
+++ b/pkg/utils/gitrepo.go
@@ -23,7 +23,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -426,7 +425,7 @@ func getKnownHostFromURL(sshURL string, filepath string) error {
 
 	klog.Info("SSH host key: " + string(stdout))
 
-	if err := ioutil.WriteFile(filepath, stdout, 0600); err != nil {
+	if err := os.WriteFile(filepath, stdout, 0600); err != nil {
 		klog.Error("failed to write known_hosts file: ", err)
 		return err
 	}
@@ -489,7 +488,7 @@ func getHTTPOptions(options *git.CloneOptions, user, password, caCerts string, i
 
 	installProtocol := false
 
-	// #nosec G402
+	// #nosec G402 -- TLS 1.2 is required for FIPS
 	clientConfig := &tls.Config{MinVersion: appv1.TLSMinVersionInt}
 
 	// skip TLS certificate verification for Git servers with custom or self-signed certs
@@ -553,7 +552,6 @@ func getHTTPOptions(options *git.CloneOptions, user, password, caCerts string, i
 		klog.Info("NO_PROXY = " + os.Getenv("NO_PROXY"))
 
 		transportConfig := &http.Transport{
-			/* #nosec G402 */
 			TLSClientConfig: clientConfig,
 		}
 
@@ -574,7 +572,6 @@ func getHTTPOptions(options *git.CloneOptions, user, password, caCerts string, i
 		}
 
 		customClient := &http.Client{
-			/* #nosec G402 */
 			Transport: transportConfig,
 
 			// 15 second timeout
@@ -814,7 +811,7 @@ func sortKubeResource(crdsAndNamespaceFiles, rbacFiles, otherFiles []string, pat
 	if strings.EqualFold(filepath.Ext(path), ".yml") || strings.EqualFold(filepath.Ext(path), ".yaml") {
 		klog.V(4).Info("Reading file: ", path)
 
-		file, err := ioutil.ReadFile(path) // #nosec G304 path is not user input
+		file, err := os.ReadFile(path) // #nosec G304 path is not user input
 
 		if err != nil {
 			klog.Error(err, "Failed to read YAML file "+path)

--- a/pkg/utils/gitrepo_test.go
+++ b/pkg/utils/gitrepo_test.go
@@ -19,7 +19,6 @@ import (
 	"crypto/tls"
 	"encoding/pem"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -290,7 +289,7 @@ func TestParseMultiDocYAML(t *testing.T) {
 	// This tests that a multi document YAML can be parsed properly
 	// and handle the --- delimiter correctly
 	// The test file contains --- characters in a resource and delimeters --- with trailing spaces
-	content, err := ioutil.ReadFile("../../test/github/multiresource/multiresource.yaml")
+	content, err := os.ReadFile("../../test/github/multiresource/multiresource.yaml")
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	items := ParseYAML(content)
@@ -1054,7 +1053,7 @@ func TestSkipHooksOnManaged(t *testing.T) {
 }
 
 func TestGetKnownHostFromURL(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "temptest")
+	tmpfile, err := os.CreateTemp("", "temptest")
 	if err != nil {
 		t.Error("error creating temp file")
 	}
@@ -1197,7 +1196,7 @@ tYny6pJJNYEhf7HPmb2O3zBuuqsCC0O2SHrgFYH350zA4To9Ez5nifkZ0CBx0pn9jWn02V
 	}
 
 	// Create Temp directory
-	tempDir, err := ioutil.TempDir("", "gitrepo")
+	tempDir, err := os.MkdirTemp("", "gitrepo")
 	if err != nil {
 		t.Error(err, " unable to create temp dir to clone repo")
 	}

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -17,7 +17,7 @@ package utils
 import (
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -62,7 +62,7 @@ func ConvertLabels(labelSelector *metav1.LabelSelector) (labels.Selector, error)
 }
 
 func GetComponentNamespace() (string, error) {
-	nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return "open-cluster-management-agent-addon", err
 	}
@@ -72,7 +72,7 @@ func GetComponentNamespace() (string, error) {
 
 // GetCheckSum generates a checksum of a kube config file
 func GetCheckSum(kubeconfigfile string) ([32]byte, error) {
-	content, err := ioutil.ReadFile(filepath.Clean(kubeconfigfile))
+	content, err := os.ReadFile(filepath.Clean(kubeconfigfile))
 	if err != nil {
 		return [32]byte{}, fmt.Errorf("read %s failed, %w", kubeconfigfile, err)
 	}

--- a/pkg/utils/kustomize.go
+++ b/pkg/utils/kustomize.go
@@ -17,7 +17,6 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -148,7 +147,7 @@ func OverrideKustomize(pov appv1.PackageOverride, kustomizeDir string) error {
 func mergeKustomization(kustomizeYamlFilePath string, override map[string]interface{}) error {
 	var master map[string]interface{}
 
-	bs, err := ioutil.ReadFile(kustomizeYamlFilePath) // #nosec G304 constructed filepath.Join(kustomizeDir, "kustomization.yaml")
+	bs, err := os.ReadFile(kustomizeYamlFilePath) // #nosec G304 constructed filepath.Join(kustomizeDir, "kustomization.yaml")
 
 	if err != nil {
 		klog.Error("Failed to read file ", kustomizeYamlFilePath, " err: ", err)
@@ -171,7 +170,7 @@ func mergeKustomization(kustomizeYamlFilePath string, override map[string]interf
 		return err
 	}
 
-	if err := ioutil.WriteFile(kustomizeYamlFilePath, bs, 0600); err != nil {
+	if err := os.WriteFile(kustomizeYamlFilePath, bs, 0600); err != nil {
 		klog.Error("Failed to overwrite kustomize file ", " err: ", err)
 		return err
 	}

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1347,7 +1346,7 @@ func GetClientConfigFromKubeConfig(kubeconfigFile string) (*rest.Config, error) 
 }
 
 func getClientConfig(kubeConfigFile string) (*rest.Config, error) {
-	kubeConfigBytes, err := ioutil.ReadFile(filepath.Clean(kubeConfigFile))
+	kubeConfigBytes, err := os.ReadFile(filepath.Clean(kubeConfigFile))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/subscription_test.go
+++ b/pkg/utils/subscription_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	e "errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -1808,7 +1807,7 @@ func TestGetClientConfigFromKubeConfig(t *testing.T) {
 func TestGetCheckSum(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	tmpFile, err := ioutil.TempFile("", "temptest")
+	tmpFile, err := os.CreateTemp("", "temptest")
 	g.Expect(err).ShouldNot(HaveOccurred())
 
 	_, err = tmpFile.WriteString("fake kubeconfig data")

--- a/pkg/webhook/listener/bitbucket_events.go
+++ b/pkg/webhook/listener/bitbucket_events.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -60,11 +60,11 @@ type BitBucketRepository struct {
 }
 
 func (listener *WebhookListener) handleBitbucketWebhook(r *http.Request) error {
-	event := r.Header.Get(BitbucketEventHeader) // has to have value. webhook_listner ensures.
+	event := r.Header.Get(BitbucketEventHeader) // has to have value. webhook_listener ensures.
 
 	klog.Info("Handling BitBucket webhook event: " + event)
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil || len(body) == 0 {
 		klog.Error("Failed to parse the payload: ", err)
 		return errors.New("failed to parse the payload")

--- a/pkg/webhook/listener/github_events.go
+++ b/pkg/webhook/listener/github_events.go
@@ -17,7 +17,7 @@ package listener
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -168,14 +168,14 @@ func (listener *WebhookListener) ParseRequest(r *http.Request) (body []byte, sig
 
 	switch contentType := r.Header.Get("Content-Type"); contentType {
 	case "application/json":
-		if body, err = ioutil.ReadAll(r.Body); err != nil {
+		if body, err = io.ReadAll(r.Body); err != nil {
 			klog.Error("Failed to read the request body. error: ", err)
 			return nil, "", nil, err
 		}
 
 		payload = body //the JSON payload
 	case "application/x-www-form-urlencoded":
-		if body, err = ioutil.ReadAll(r.Body); err != nil {
+		if body, err = io.ReadAll(r.Body); err != nil {
 			klog.Error("Failed to read the request body. error: ", err)
 			return nil, "", nil, err
 		}

--- a/pkg/webhook/listener/gitlab_events.go
+++ b/pkg/webhook/listener/gitlab_events.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -51,11 +51,11 @@ type GitLabRepository struct {
 }
 
 func (listener *WebhookListener) handleGitlabWebhook(r *http.Request) error {
-	event := r.Header.Get(GitlabEventHeader) // has to have value. webhook_listner ensures.
+	event := r.Header.Get(GitlabEventHeader) // has to have value. webhook_listener ensures.
 
 	klog.Info("Handling GitLab webhook event: " + event)
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil || len(body) == 0 {
 		klog.Error("Failed to parse the payload: ", err)
 		return errors.New("failed to parse the payload")

--- a/pkg/webhook/listener/webhook_listener_test.go
+++ b/pkg/webhook/listener/webhook_listener_test.go
@@ -440,7 +440,7 @@ func TestServiceCreation(t *testing.T) {
 
 	os.Setenv("DEPLOYMENT_LABEL", "test-deployment")
 
-	err = createWebhookListnerService(c, "default")
+	err = createWebhookListenerService(c, "default")
 	// It will fail because the deployment resource for the owner reference is not found in the cluster.
 	g.Expect(err).To(gomega.HaveOccurred())
 }


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.

- Rename "Listner" to "Listener"
- Clean up gosec violations
- Address ioutil deprecation
