### PR TITLE
[manual-sync] Upgrade to Go 1.22

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.21-linux AS plugin-builder
-ENV POLICY_GENERATOR_TAG=release-2.12
+FROM registry.ci.openshift.org/stolostron/builder:go1.22-linux AS plugin-builder
+ENV POLICY_GENERATOR_TAG=release-2.13
 
 WORKDIR /go/src/github.com/open-cluster-management/multicloud-operators-subscription
 COPY . .

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,5 +1,5 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.21-linux AS builder
-ENV POLICY_GENERATOR_TAG=release-2.12
+FROM registry.ci.openshift.org/stolostron/builder:go1.22-linux AS builder
+ENV POLICY_GENERATOR_TAG=release-2.13
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-subscription
 COPY . .

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,5 +1,5 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 AS plugin-builder
-ENV POLICY_GENERATOR_TAG=release-2.12
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS plugin-builder
+ENV POLICY_GENERATOR_TAG=release-2.13
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-subscription
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/multicloud-operators-subscription
 
-go 1.21
+go 1.22.10
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/pkg/controller/appsubsummary/appsubsummary_controller.go
+++ b/pkg/controller/appsubsummary/appsubsummary_controller.go
@@ -286,9 +286,6 @@ func (r *ReconcileAppSubSummary) cleanManagedClusterViewPerApp(appsubName, appsu
 			continue
 		}
 
-		// reassign the iteration variable inside the loop to avoid the sonarcloud warning - "Implicit memory aliasing in for loop"
-		managedClusterView := managedClusterView
-
 		if err = r.Delete(context.TODO(), &managedClusterView); err != nil {
 			klog.Errorf("Error deleting managedClusterView :%v/%v, err:%v", managedClusterView.Namespace, managedClusterView.Name, err)
 		}

--- a/pkg/controller/mcmhub/ansiblejob.go
+++ b/pkg/controller/mcmhub/ansiblejob.go
@@ -73,8 +73,8 @@ func findLastAnsibleJob(clt client.Client, subIns *subv1.Subscription, hookType 
 
 	klog.Infof("total prehook/posthook ansible jobs num: %v", len(ansibleJobList.Items))
 
-	for i := 0; i < len(ansibleJobList.Items); i++ {
-		hostingAppsub, ok := ansibleJobList.Items[i].Annotations[subv1.AnnotationHosting]
+	for _, ansibleJob := range ansibleJobList.Items {
+		hostingAppsub, ok := ansibleJob.Annotations[subv1.AnnotationHosting]
 
 		if !ok {
 			continue
@@ -84,7 +84,7 @@ func findLastAnsibleJob(clt client.Client, subIns *subv1.Subscription, hookType 
 			continue
 		}
 
-		curHookType, ok := ansibleJobList.Items[i].Annotations[subv1.AnnotationHookType]
+		curHookType, ok := ansibleJob.Annotations[subv1.AnnotationHookType]
 
 		if !ok {
 			continue
@@ -94,7 +94,7 @@ func findLastAnsibleJob(clt client.Client, subIns *subv1.Subscription, hookType 
 			continue
 		}
 
-		hookTpl, ok := ansibleJobList.Items[i].Annotations[subv1.AnnotationHookTemplate]
+		hookTpl, ok := ansibleJob.Annotations[subv1.AnnotationHookTemplate]
 
 		if !ok {
 			continue
@@ -104,7 +104,7 @@ func findLastAnsibleJob(clt client.Client, subIns *subv1.Subscription, hookType 
 			continue
 		}
 
-		lastAnsibleJob := ansibleJobList.Items[i].DeepCopy()
+		lastAnsibleJob := ansibleJob.DeepCopy()
 
 		klog.Infof("last ansible job: %v/%v, hookType: %v, hookTemplate: %v", lastAnsibleJob.Namespace, lastAnsibleJob.Name, hookType, jobKey.String())
 

--- a/pkg/controller/mcmhub/gitrepo_sync.go
+++ b/pkg/controller/mcmhub/gitrepo_sync.go
@@ -263,6 +263,7 @@ func (r *ReconcileSubscription) subscribeKustomizations(sub *appv1.Subscription,
 	for _, kustomizeDir := range kustomizeDirs {
 		klog.Info("Applying kustomization ", kustomizeDir)
 
+		//nolint:copyloopvar
 		relativePath := kustomizeDir
 
 		if len(strings.SplitAfter(kustomizeDir, baseDir+"/")) > 1 {

--- a/pkg/controller/mcmhub/propagate_manifestwork.go
+++ b/pkg/controller/mcmhub/propagate_manifestwork.go
@@ -277,8 +277,8 @@ func (r *ReconcileSubscription) setLocalManifestWork(cluster ManageClusters, hos
 		},
 	}
 
-	for i := 0; i < len(localManifestWork.Spec.Workload.Manifests); i++ {
-		klog.V(1).Infof("workload manifest: %#v", string(localManifestWork.Spec.Workload.Manifests[i].Raw))
+	for _, manifest := range localManifestWork.Spec.Workload.Manifests {
+		klog.V(1).Infof("workload manifest: %#v", string(manifest.Raw))
 	}
 
 	return localManifestWork, nil

--- a/pkg/placementrule/controller/placementrule/placementdecision.go
+++ b/pkg/placementrule/controller/placementrule/placementdecision.go
@@ -122,8 +122,6 @@ func (r *ReconcilePlacementRuleStatus) syncPlacementDecisions(ctx context.Contex
 			continue
 		}
 
-		placementDecision := placementDecision
-
 		err := r.Delete(ctx, &placementDecision)
 		if errors.IsNotFound(err) {
 			continue

--- a/pkg/placementrule/utils/auth.go
+++ b/pkg/placementrule/utils/auth.go
@@ -169,6 +169,7 @@ func IfClusterAdmin(user string, groups []string) bool {
 	}
 
 	for _, group := range groups {
+		//nolint:copyloopvar
 		newGroup := group
 
 		gg := strings.Split(group, ":")

--- a/pkg/placementrule/utils/eventlog.go
+++ b/pkg/placementrule/utils/eventlog.go
@@ -84,11 +84,11 @@ func NewEventRecorder(cfg *rest.Config, scheme *apiruntime.Scheme) (*EventRecord
 // RecordEvent - record kuberentes event
 func (rec *EventRecorder) RecordEvent(obj apiruntime.Object, reason, msg string, err error) {
 	eventType := corev1.EventTypeNormal
-	evnetMsg := msg
+	eventMsg := msg
 
 	if err != nil {
 		eventType = corev1.EventTypeWarning
 	}
 
-	rec.EventRecorder.Event(obj, eventType, reason, evnetMsg)
+	rec.EventRecorder.Event(obj, eventType, reason, eventMsg)
 }

--- a/pkg/subscriber/git/git_subscriber_item.go
+++ b/pkg/subscriber/git/git_subscriber_item.go
@@ -454,6 +454,7 @@ func (ghsi *SubscriberItem) subscribeKustomizations() error {
 	for _, kustomizeDir := range ghsi.kustomizeDirs {
 		klog.Info("Applying kustomization ", kustomizeDir)
 
+		//nolint:copyloopvar
 		relativePath := kustomizeDir
 
 		if len(strings.SplitAfter(kustomizeDir, ghsi.repoRoot+"/")) > 1 {

--- a/pkg/subscriber/objectbucket/objectbucket_subscriber_item.go
+++ b/pkg/subscriber/objectbucket/objectbucket_subscriber_item.go
@@ -372,7 +372,6 @@ func (obsi *SubscriberItem) doSubscription() {
 	var doErr error
 
 	for _, tpl := range tpls {
-		tpl := tpl
 		resource, err := obsi.doSubscribeManifest(&tpl) // this is now the address of the inner tpl
 
 		if err != nil {

--- a/pkg/synchronizer/kubernetes/sync_server.go
+++ b/pkg/synchronizer/kubernetes/sync_server.go
@@ -246,8 +246,6 @@ func cleanup(synchronizer *KubeSynchronizer) {
 
 	if appsubStatusList != nil && len(appsubStatusList.Items) > 0 {
 		for _, appsubStatus := range appsubStatusList.Items {
-			appsubStatus := appsubStatus
-
 			appsub := &appv1.Subscription{}
 
 			nsn := types.NamespacedName{Namespace: appsubStatus.Namespace, Name: appsubStatus.Name}

--- a/pkg/synchronizer/kubernetes/synchronizer.go
+++ b/pkg/synchronizer/kubernetes/synchronizer.go
@@ -279,8 +279,6 @@ func (sync *KubeSynchronizer) ProcessSubResources(appsub *appv1alpha1.Subscripti
 	for _, resource := range resources {
 		appSubUnitStatus := SubscriptionUnitStatus{}
 
-		resource := resource
-
 		template, err := sync.OverrideResource(hostSub, &resource)
 
 		if err != nil {

--- a/pkg/utils/eventlog.go
+++ b/pkg/utils/eventlog.go
@@ -84,11 +84,11 @@ func NewEventRecorder(cfg *rest.Config, scheme *apiruntime.Scheme) (*EventRecord
 // RecordEvent - record kuberentes event
 func (rec *EventRecorder) RecordEvent(obj apiruntime.Object, reason, msg string, err error) {
 	eventType := corev1.EventTypeNormal
-	evnetMsg := msg
+	eventMsg := msg
 
 	if err != nil {
 		eventType = corev1.EventTypeWarning
 	}
 
-	rec.EventRecorder.Event(obj, eventType, reason, evnetMsg)
+	rec.EventRecorder.Event(obj, eventType, reason, eventMsg)
 }

--- a/pkg/utils/helmrepo.go
+++ b/pkg/utils/helmrepo.go
@@ -679,7 +679,6 @@ func DeleteHelmReleaseCRD(runtimeClient client.Client, crdx *clientsetx.Clientse
 		os.Exit(0)
 	} else {
 		for _, hr := range hrlist.Items {
-			hr := hr
 			klog.V(1).Infof("Found %s", hr.SelfLink)
 			// remove all finalizers
 			hr = *hr.DeepCopy()

--- a/pkg/utils/subscription.go
+++ b/pkg/utils/subscription.go
@@ -1070,7 +1070,7 @@ func CompareManifestWork(oldManifestWork, newManifestWork *manifestWorkV1.Manife
 		return false
 	}
 
-	for i := 0; i < len(oldManifestWork.Spec.Workload.Manifests); i++ {
+	for i := range oldManifestWork.Spec.Workload.Manifests {
 		oldManifest := &unstructured.Unstructured{}
 		newManifest := &unstructured.Unstructured{}
 

--- a/pkg/utils/subscription_test.go
+++ b/pkg/utils/subscription_test.go
@@ -642,7 +642,6 @@ func TestIsEqaulSubscriptionStatus(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			actual := isEqualSubscriptionStatus(tt.givena, tt.givenb)
 
@@ -666,7 +665,6 @@ func TestIsEmptySubscriptionStatus(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			actual := isEmptySubscriptionStatus(tt.given)
 			if actual != tt.expected {
@@ -945,7 +943,6 @@ func TestIsSubscriptionBasicChanged(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			actual := IsSubscriptionBasicChanged(tt.oldIns, tt.newIns)
 			if actual != tt.expected {

--- a/pkg/utils/timewindow_test.go
+++ b/pkg/utils/timewindow_test.go
@@ -420,7 +420,7 @@ func assertHourRangesInTime(t *testing.T, got, wanted []hourRangesInTime) {
 		t.Fatalf("validateHourRange length is wrong, got %v, wanted %v", len(got), len(wanted))
 	}
 
-	for i := 0; i < len(got); i++ {
+	for i := range got {
 		if got[i].start.Equal(wanted[i].start) == false {
 			t.Errorf("item idx %v got %v, wanted %v", i, got[i].start.String(), wanted[i].start.String())
 		}


### PR DESCRIPTION
Manual sync of:
- https://github.com/open-cluster-management-io/multicloud-operators-subscription/pull/415

* Upgrade to Go 1.22
* Fix Go 1.22 linting issues

(cherry picked from commit d284803a6d8927a178476bfe84e4c2f364bdaabc)

* [x] I have taken backward compatibility into consideration.

Resolves:
- https://github.com/stolostron/multicloud-operators-subscription/issues/1148