### PR TITLE
bump go to 1.21 for docker.prow only

### DIFF
--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.20-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.21-linux AS builder
 ENV POLICY_GENERATOR_TAG=release-2.9
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-subscription


### PR DESCRIPTION
* [X] I have taken backward compatibility into consideration.
