### PR TITLE
Bump policy generator to 2.14

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/stolostron/builder:go1.23-linux AS plugin-builder
-ENV POLICY_GENERATOR_TAG=release-2.13
+ENV POLICY_GENERATOR_TAG=release-2.14
 
 WORKDIR /go/src/github.com/open-cluster-management/multicloud-operators-subscription
 COPY . .

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/stolostron/builder:go1.23-linux AS builder
-ENV POLICY_GENERATOR_TAG=release-2.13
+ENV POLICY_GENERATOR_TAG=release-2.14
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-subscription
 COPY . .

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,5 +1,5 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS plugin-builder
-ENV POLICY_GENERATOR_TAG=release-2.13
+ENV POLICY_GENERATOR_TAG=release-2.14
 
 WORKDIR /go/src/github.com/stolostron/multicluster-operators-subscription
 COPY . .


### PR DESCRIPTION
* [x] I have taken backward compatibility into consideration.

Closes #https://github.com/stolostron/multicloud-operators-subscription/issues/1210