### PR TITLE
[release-2.9] feat: Add an annotation to allow for hub appsub bypassing Git clone

### DIFF
--- a/pkg/apis/apps/v1/subscription_types.go
+++ b/pkg/apis/apps/v1/subscription_types.go
@@ -94,6 +94,8 @@ var (
 	AnnotationHostingDeployable = SchemeGroupVersion.Group + "/hosting-deployable"
 	// AnnotationCurrentNamespaceScoped specifies to deloy resources into subscription namespace
 	AnnotationCurrentNamespaceScoped = SchemeGroupVersion.Group + "/current-namespace-scoped"
+	// AnnotationSkipHubValidation indicates the hub subscription should skip the "dry-run" validations and proceed to propagation phase
+	AnnotationSkipHubValidation = SchemeGroupVersion.Group + "/skip-hub-validation"
 )
 
 const (

--- a/pkg/controller/mcmhub/hub.go
+++ b/pkg/controller/mcmhub/hub.go
@@ -93,6 +93,17 @@ func (r *ReconcileSubscription) doMCMHubReconcile(sub *appv1.Subscription) error
 	// Add or sync application labels
 	r.AddAppLabels(sub)
 
+	// Skip fetching resources and creating appsub report if skip hub validation is true
+	if shouldSkipHubValidation(sub) {
+		clusters, err := r.getClustersByPlacement(sub)
+		if err != nil {
+			klog.Error("Error in getting clusters:", err)
+			return err
+		}
+
+		return r.PropagateAppSubManifestWork(sub, clusters)
+	}
+
 	var resources []*v1.ObjectReference
 
 	switch tp := strings.ToLower(string(primaryChannel.Spec.Type)); tp {

--- a/pkg/controller/mcmhub/hub_git.go
+++ b/pkg/controller/mcmhub/hub_git.go
@@ -340,6 +340,11 @@ func (h *HubGitOps) ResolveLocalGitFolder(subIns *subv1.Subscription) string {
 }
 
 func (h *HubGitOps) RegisterBranch(subIns *subv1.Subscription) error {
+	if shouldSkipHubValidation(subIns) {
+		h.logger.Info("skipping register branch for appsub " + subIns.Namespace + "/" + subIns.Name)
+		return nil
+	}
+
 	subKey := types.NamespacedName{Name: subIns.GetName(), Namespace: subIns.GetNamespace()}
 
 	// This does not pick up new changes to channel configuration
@@ -764,4 +769,13 @@ func (h *HubGitOps) GetHooks(subIns *subv1.Subscription, hookPath string) ([]ans
 	}
 
 	return parseAsAnsibleJobs(sortedRes.kubRes, parseAnsibleJobResoures, h.logger)
+}
+
+func shouldSkipHubValidation(subIns *subv1.Subscription) bool {
+	annos := subIns.GetAnnotations()
+	if len(annos) > 0 && annos[subv1.AnnotationSkipHubValidation] == "true" {
+		return true
+	}
+
+	return false
 }

--- a/pkg/controller/mcmhub/hub_git_test.go
+++ b/pkg/controller/mcmhub/hub_git_test.go
@@ -431,3 +431,50 @@ var _ = PDescribe("hub git ops", func() {
 		Eventually(detectTargetCommit(subKey, defaultCommit), specTimeOut, pullInterval).Should(Succeed())
 	})
 })
+
+var _ = Describe("shouldSkipHubValidation", func() {
+	var (
+		sub *subv1.Subscription
+	)
+	BeforeEach(func() {
+		sub = &subv1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sub",
+				Namespace: "default",
+			},
+		}
+	})
+	It("should return false when annotation is nil", func() {
+		Expect(shouldSkipHubValidation(sub)).To(BeFalse())
+	})
+	It("should return false when skip annotation is missing", func() {
+		sub.SetAnnotations(map[string]string{
+			"foobar": "true",
+		})
+		Expect(shouldSkipHubValidation(sub)).To(BeFalse())
+	})
+	It("should return true when skip annotation is true'", func() {
+		sub.SetAnnotations(map[string]string{
+			subv1.AnnotationSkipHubValidation: "true",
+		})
+		Expect(shouldSkipHubValidation(sub)).To(BeTrue())
+	})
+	It("should return false when skip annotation is empty", func() {
+		sub.SetAnnotations(map[string]string{
+			subv1.AnnotationSkipHubValidation: "",
+		})
+		Expect(shouldSkipHubValidation(sub)).To(BeFalse())
+	})
+	It("should return false when skip annotation is false", func() {
+		sub.SetAnnotations(map[string]string{
+			subv1.AnnotationSkipHubValidation: "false",
+		})
+		Expect(shouldSkipHubValidation(sub)).To(BeFalse())
+	})
+	It("should return false when skip annotation is non boolean string values", func() {
+		sub.SetAnnotations(map[string]string{
+			subv1.AnnotationSkipHubValidation: "foobar",
+		})
+		Expect(shouldSkipHubValidation(sub)).To(BeFalse())
+	})
+})


### PR DESCRIPTION
feat: Add an annotation to allow for hub appsub bypassing Git clone operations to speed up appsub propagation to managed cluster

* [x] I have taken backward compatibility into consideration.
