### PR TITLE
gitops addon ManagedClusterAddOn failure with ManagedClusterAddOnLeas…

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/gitops-addon.clusterManagementAddon.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/gitops-addon.clusterManagementAddon.yaml
@@ -2,8 +2,6 @@ apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: ClusterManagementAddOn
 metadata:
   name: gitops-addon
-  annotations:
-    addon.open-cluster-management.io/lifecycle: "gitops-addon"
 spec:
   addOnMeta:
     description: gitops-addon


### PR DESCRIPTION
…eNotFound error

* [X] I have taken backward compatibility into consideration.

https://issues.redhat.com/browse/ACM-20204

