### PR TITLE
timzone data is missed to install when building subscription image in Konflux pipe…

### DIFF
--- a/pkg/utils/timewindow.go
+++ b/pkg/utils/timewindow.go
@@ -17,7 +17,9 @@ package utils
 import (
 	"sort"
 	"strings"
+
 	"time"
+	_ "time/tzdata" // This line embeds the timezone database.
 
 	"k8s.io/klog"
 


### PR DESCRIPTION
…line

* [X] I have taken backward compatibility into consideration.

https://issues.redhat.com/browse/ACM-21499