### PR TITLE
feat: adding argocd-agent to gitops addon requires the following install related manifests changes

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/apps.open-cluster-management.io_gitopsclusters_crd_v1beta1.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/apps.open-cluster-management.io_gitopsclusters_crd_v1beta1.yaml
@@ -35,6 +35,15 @@ spec:
           spec:
             description: GitOpsClusterSpec defines the desired state of GitOpsCluster.
             properties:
+              argoCDAgent:
+                description: ArgoCDAgent defines the configuration for the ArgoCD agent.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enabled indicates whether the ArgoCD agent is enabled.
+                      Default is false.
+                    type: boolean
+                type: object
               argoServer:
                 description: ArgoServerSpec specifies the location of the Argo CD
                   server.

--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/gitops-addon.addonTemplates.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/gitops-addon.addonTemplates.yaml
@@ -4,6 +4,13 @@ metadata:
   name: gitops-addon
 spec:
   addonName: gitops-addon
+  registration:
+    - type: CustomSigner
+      customSigner:
+        signerName: open-cluster-management.io/argocd-agent-addon
+        signingCA:
+          name: argocd-agent-ca
+          namespace: openshift-gitops
   agentSpec:
       workload:
         manifests:
@@ -56,6 +63,16 @@ spec:
                           value: '{{RECONCILE_SCOPE}}'
                         - name: ACTION
                           value: '{{ACTION}}'
+                        - name: ARGOCD_AGENT_ENABLED
+                          value: '{{ARGOCD_AGENT_ENABLED}}'
+                        - name: ARGOCD_AGENT_IMAGE
+                          value: '{{ARGOCD_AGENT_IMAGE}}'
+                        - name: ARGOCD_AGENT_SERVER_ADDRESS
+                          value: '{{ARGOCD_AGENT_SERVER_ADDRESS}}'
+                        - name: ARGOCD_AGENT_SERVER_PORT
+                          value: '{{ARGOCD_AGENT_SERVER_PORT}}'
+                        - name: ARGOCD_AGENT_MODE
+                          value: '{{ARGOCD_AGENT_MODE}}'
                   volumes:
                     - name: tmp-volume
                       emptyDir: {}

--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -403,6 +403,7 @@ spec:
           - configmaps
           - endpoints
           - events
+          - namespaces
           - secrets
           - serviceaccounts
           - services


### PR DESCRIPTION
feat: adding argocd-agent to gitops addon requires the following install related manifests changes

see https://github.com/stolostron/multicloud-integrations/pull/386 for more details.

* [x] I have taken backward compatibility into consideration.
