### PR TITLE
Grant multicluster-applications SA get on namespaces (release-2.13)

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -403,6 +403,7 @@ spec:
           - configmaps
           - endpoints
           - events
+          - namespaces
           - secrets
           - serviceaccounts
           - services


### PR DESCRIPTION
The GitOpsCluster controller's cross-namespace argoNamespace check (added as part of the CVE-2026-70398 fix) requires the multicluster-applications service account to read Namespace objects in order to verify the target namespace before writing ArgoCD cluster secrets into it.

The 'namespaces' resource is already present in this same core-group rule on main, but was never backported to release-2.13, so any GitOpsCluster with a cross-namespace argoServer.argoNamespace fails permanently with:

  unable to verify target argoNamespace "...": namespaces "..." is
  forbidden: User "system:serviceaccount:open-cluster-management:
  multicluster-applications" cannot get resource "namespaces"

confirmed on a live ACM 2.13.11 hub (Red Hat case 04529447).

* [ ] I have taken backward compatibility into consideration.
