### PR TITLE
Grant multicluster-applications SA get on namespaces (release-2.14)

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -403,6 +403,7 @@ spec:
           - configmaps
           - endpoints
           - events
+          - namespaces
           - secrets
           - serviceaccounts
           - services


### PR DESCRIPTION
Same gap as release-2.13: the GitOpsCluster controller's cross-namespace argoNamespace check (CVE-2026-70398 fix) requires the multicluster-applications service account to read Namespace objects, but 'namespaces' was never backported to release-2.14's bundled clusterPermissions for this SA (present on main).

Independently reproduced and confirmed by Red Hat engineering (Yupeng Chang) on a live ACM 2.14 environment, and on a live ACM 2.13.11 hub in Red Hat case 04529447:

  unable to verify target argoNamespace "...": namespaces "..." is
  forbidden: User "system:serviceaccount:open-cluster-management:
  multicluster-applications" cannot get resource "namespaces"

See companion release-2.13 fix for the same one-line change.

* [ ] I have taken backward compatibility into consideration.
