### PR TITLE
Grant multicluster-applications SA get on namespaces (release-2.12)

### DIFF
--- a/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multicluster-operators-subscription/manifests/multicluster-operators-subscription.clusterserviceversion.yaml
@@ -403,6 +403,7 @@ spec:
           - configmaps
           - endpoints
           - events
+          - namespaces
           - secrets
           - serviceaccounts
           - services


### PR DESCRIPTION
Same gap as release-2.13/2.14: the GitOpsCluster controller's cross-namespace argoNamespace check (CVE-2026-70398 fix) requires the multicluster-applications service account to read Namespace objects, but 'namespaces' was never backported to release-2.12's bundled clusterPermissions for this SA (present on main).

See companion release-2.13 (#1745) and release-2.14 (#1746) fixes for the same one-line change.

* [X] I have taken backward compatibility into consideration.
